### PR TITLE
Add point values structural analysis

### DIFF
--- a/src/main/java/org/commrogue/IndexAnalyzerRequestHandler.java
+++ b/src/main/java/org/commrogue/IndexAnalyzerRequestHandler.java
@@ -19,6 +19,8 @@ import org.commrogue.analysis.iindex.InvertedIndexAnalysis;
 import org.commrogue.analysis.iindex.TermStructureAnalysisMode;
 import org.commrogue.analysis.knn.KnnVectorsAnalysis;
 import org.commrogue.analysis.knn.KnnVectorsAnalysisMode;
+import org.commrogue.analysis.points.PointValuesAnalysis;
+import org.commrogue.analysis.points.PointValuesAnalysisMode;
 import org.commrogue.analysis.storedfields.StoredFieldsAnalysis;
 import org.commrogue.analysis.storedfields.StoredFieldsAnalysisMode;
 import org.commrogue.lucene.Utils;
@@ -46,6 +48,11 @@ public class IndexAnalyzerRequestHandler extends RequestHandlerBase {
                         req.getParams().get("docValuesAnalysisMode"))
                 .map(DocValuesAnalysisMode::fromParam)
                 .orElse(DocValuesAnalysisMode.STRUCTURAL_WITH_FALLBACK);
+
+        PointValuesAnalysisMode pointValuesAnalysisMode = Optional.ofNullable(
+                        req.getParams().get("pointValuesAnalysisMode"))
+                .map(PointValuesAnalysisMode::fromParam)
+                .orElse(PointValuesAnalysisMode.STRUCTURAL_WITH_FALLBACK);
 
         StoredFieldsAnalysisMode storedFieldsAnalysisMode = Optional.ofNullable(
                         req.getParams().get("storedFieldsAnalysisMode"))
@@ -88,6 +95,8 @@ public class IndexAnalyzerRequestHandler extends RequestHandlerBase {
                         targetDirectory, segmentReader, indexAnalysisResult, false, analysisMode));
                 analysisList.add(new DocValuesAnalysis(
                         targetDirectory, segmentReader, indexAnalysisResult, docValuesAnalysisMode));
+                analysisList.add(new PointValuesAnalysis(
+                        targetDirectory, segmentReader, indexAnalysisResult, pointValuesAnalysisMode));
                 analysisList.add(
                         new KnnVectorsAnalysis(targetDirectory, segmentReader, indexAnalysisResult, knnAnalysisMode));
                 analysisList.add(new StoredFieldsAnalysis(

--- a/src/main/java/org/commrogue/analysis/points/PointValuesAnalysis.java
+++ b/src/main/java/org/commrogue/analysis/points/PointValuesAnalysis.java
@@ -1,0 +1,450 @@
+package org.commrogue.analysis.points;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.NoSuchFileException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.codecs.lucene90.Lucene90PointsFormat;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FieldInfos;
+import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.index.PointValues;
+import org.apache.lucene.index.PointValues.IntersectVisitor;
+import org.apache.lucene.index.PointValues.Relation;
+import org.apache.lucene.index.SegmentCommitInfo;
+import org.apache.lucene.index.SegmentReader;
+import org.apache.lucene.store.ChecksumIndexInput;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.util.bkd.BKDWriter;
+import org.commrogue.LuceneFileExtension;
+import org.commrogue.analysis.Analysis;
+import org.commrogue.results.FieldAnalysis;
+import org.commrogue.results.IndexAnalysisResult;
+import org.commrogue.results.PointValuesFieldAnalysis;
+import org.commrogue.tracking.TrackingReadBytesDirectory;
+
+public class PointValuesAnalysis implements Analysis {
+    private final TrackingReadBytesDirectory directory;
+    private final SegmentReader segmentReader;
+    private final IndexAnalysisResult indexAnalysisResult;
+    private final PointValuesAnalysisMode analysisMode;
+
+    private record FieldPointValuesSizes(long metaBytes, long indexBytes, long dataBytes) {}
+
+    public PointValuesAnalysis(
+            TrackingReadBytesDirectory directory,
+            SegmentReader segmentReader,
+            IndexAnalysisResult indexAnalysisResult,
+            PointValuesAnalysisMode analysisMode) {
+        this.directory = directory;
+        this.segmentReader = segmentReader;
+        this.indexAnalysisResult = indexAnalysisResult;
+        this.analysisMode = analysisMode;
+    }
+
+    @Override
+    public void analyze() throws Exception {
+        FieldInfos fieldInfos = segmentReader.getFieldInfos();
+        List<FieldInfo> pointFields = new ArrayList<>();
+        for (FieldInfo fieldInfo : fieldInfos) {
+            if (fieldInfo.getPointDimensionCount() > 0) {
+                pointFields.add(fieldInfo);
+            }
+        }
+
+        if (pointFields.isEmpty()) {
+            return;
+        }
+
+        Set<String> processedFields = new HashSet<>();
+        boolean structuralData = false;
+
+        if (analysisMode != PointValuesAnalysisMode.INSTRUMENTED) {
+            try {
+                structuralData = analyzeStructurally(pointFields, processedFields);
+            } catch (Exception e) {
+                if (analysisMode == PointValuesAnalysisMode.STRUCTURAL) {
+                    throw e;
+                }
+            }
+        }
+
+        if ((analysisMode == PointValuesAnalysisMode.INSTRUMENTED)
+                || (!structuralData && analysisMode != PointValuesAnalysisMode.STRUCTURAL)) {
+            analyzeByInstrumentation(pointFields, processedFields);
+        }
+    }
+
+    private boolean analyzeStructurally(List<FieldInfo> pointFields, Set<String> processedFields) throws IOException {
+        Lucene90PointsInspector inspector = new Lucene90PointsInspector(directory, segmentReader);
+        Map<String, FieldPointValuesSizes> sizes = inspector.inspect(pointFields);
+        if (sizes.isEmpty()) {
+            return false;
+        }
+
+        for (Map.Entry<String, FieldPointValuesSizes> entry : sizes.entrySet()) {
+            FieldAnalysis fieldAnalysis = indexAnalysisResult.getFieldAnalysis(entry.getKey());
+            PointValuesFieldAnalysis pointValues =
+                    ensureFieldAnalysis(fieldAnalysis, PointValuesAnalysisMode.STRUCTURAL);
+            FieldPointValuesSizes value = entry.getValue();
+            if (value.metaBytes() > 0) {
+                pointValues.addTrackingByExtension(LuceneFileExtension.KDM, value.metaBytes());
+            }
+            if (value.indexBytes() > 0) {
+                pointValues.addTrackingByExtension(LuceneFileExtension.KDI, value.indexBytes());
+            }
+            if (value.dataBytes() > 0) {
+                pointValues.addTrackingByExtension(LuceneFileExtension.KDD, value.dataBytes());
+            }
+            processedFields.add(entry.getKey());
+        }
+
+        return true;
+    }
+
+    private void analyzeByInstrumentation(List<FieldInfo> fields, Set<String> processedFields) throws IOException {
+        for (FieldInfo field : fields) {
+            if (!processedFields.add(field.name)) {
+                continue;
+            }
+
+            PointValues values = segmentReader.getPointValues(field.name);
+            if (values == null) {
+                continue;
+            }
+
+            directory.resetBytesRead();
+            values.intersect(new ExhaustiveIntersectVisitor());
+
+            FieldAnalysis fieldAnalysis = indexAnalysisResult.getFieldAnalysis(field.name);
+            PointValuesFieldAnalysis pointValues =
+                    ensureFieldAnalysis(fieldAnalysis, PointValuesAnalysisMode.INSTRUMENTED);
+            pointValues.addTrackingByDirectory(directory);
+            directory.resetBytesRead();
+        }
+    }
+
+    private PointValuesFieldAnalysis ensureFieldAnalysis(FieldAnalysis fieldAnalysis, PointValuesAnalysisMode mode) {
+        if (fieldAnalysis.pointValues == null || fieldAnalysis.pointValues.analysisMode.priority() < mode.priority()) {
+            fieldAnalysis.pointValues = new PointValuesFieldAnalysis(mode);
+        }
+        return fieldAnalysis.pointValues;
+    }
+
+    private static final class ExhaustiveIntersectVisitor implements IntersectVisitor {
+        @Override
+        public void visit(int docID) {
+            // Exhaustive traversal does not need to record anything.
+        }
+
+        @Override
+        public void visit(int docID, byte[] packedValue) {
+            // Accessing the packed value forces the BKD reader to touch the leaf data.
+        }
+
+        @Override
+        public Relation compare(byte[] minPackedValue, byte[] maxPackedValue) {
+            return Relation.CELL_CROSSES_QUERY;
+        }
+    }
+
+    private static final class Lucene90PointsInspector {
+        private static final String META_CODEC_NAME = "Lucene90PointsFormatMeta";
+        private static final String INDEX_CODEC_NAME = "Lucene90PointsFormatIndex";
+        private static final String DATA_CODEC_NAME = "Lucene90PointsFormatData";
+        private static final int LUCENE90_VERSION_START = 0;
+        private static final int LUCENE90_VERSION_CURRENT = 0;
+
+        private final TrackingReadBytesDirectory directory;
+        private final SegmentReader segmentReader;
+
+        private Lucene90PointsInspector(TrackingReadBytesDirectory directory, SegmentReader segmentReader) {
+            this.directory = directory;
+            this.segmentReader = segmentReader;
+        }
+
+        Map<String, FieldPointValuesSizes> inspect(List<FieldInfo> fields) throws IOException {
+            if (fields.isEmpty()) {
+                return Map.of();
+            }
+
+            Map<Integer, FieldInfo> fieldInfosByNumber = new HashMap<>();
+            for (FieldInfo field : fields) {
+                fieldInfosByNumber.put(field.number, field);
+            }
+
+            Map<Integer, FieldPointValuesSizesMutable> sizesByNumber = new LinkedHashMap<>();
+            for (FieldInfo field : fields) {
+                sizesByNumber.put(field.number, new FieldPointValuesSizesMutable());
+            }
+
+            SegmentCommitInfo segmentCommitInfo = segmentReader.getSegmentInfo();
+            String segmentName = segmentReader.getSegmentName();
+            byte[] segmentId = segmentCommitInfo.info.getId();
+
+            String metaName = IndexFileNames.segmentFileName(segmentName, "", Lucene90PointsFormat.META_EXTENSION);
+
+            List<FieldEntry> entries = new ArrayList<>();
+            long headerBytes = 0L;
+            long sentinelBytes = 0L;
+            long footerBytes = 0L;
+            long indexLength = 0L;
+            long dataLength = 0L;
+
+            try (ChecksumIndexInput metaInput = directory.openChecksumInput(metaName, IOContext.READONCE)) {
+                CodecUtil.checkIndexHeader(
+                        metaInput, META_CODEC_NAME, LUCENE90_VERSION_START, LUCENE90_VERSION_CURRENT, segmentId, "");
+                headerBytes = metaInput.getFilePointer();
+
+                while (true) {
+                    long entryStart = metaInput.getFilePointer();
+                    int fieldNumber = metaInput.readInt();
+                    if (fieldNumber == -1) {
+                        sentinelBytes = metaInput.getFilePointer() - entryStart;
+                        break;
+                    }
+
+                    Lucene90FieldMetadata metadata = readFieldMetadata(metaInput);
+                    long entryEnd = metaInput.getFilePointer();
+
+                    FieldPointValuesSizesMutable sizes =
+                            sizesByNumber.computeIfAbsent(fieldNumber, key -> new FieldPointValuesSizesMutable());
+                    sizes.addMetaBytes(entryEnd - entryStart);
+
+                    FieldInfo fieldInfo = fieldInfosByNumber.get(fieldNumber);
+                    if (fieldInfo == null) {
+                        fieldInfo = segmentReader.getFieldInfos().fieldInfo(fieldNumber);
+                    }
+                    entries.add(new FieldEntry(fieldInfo, metadata));
+                }
+
+                indexLength = metaInput.readLong();
+                dataLength = metaInput.readLong();
+                long footerStart = metaInput.getFilePointer();
+                CodecUtil.checkFooter(metaInput);
+                footerBytes = metaInput.length() - footerStart;
+            } catch (FileNotFoundException | NoSuchFileException e) {
+                return Map.of();
+            }
+
+            if (entries.isEmpty()) {
+                return Map.of();
+            }
+
+            long metaOverhead = headerBytes + sentinelBytes + footerBytes + Long.BYTES * 2L;
+            FieldPointValuesSizesMutable firstEntry = firstMutable(entries, sizesByNumber);
+            if (metaOverhead > 0 && firstEntry != null) {
+                firstEntry.addMetaBytes(metaOverhead);
+            }
+
+            assignIndexSizes(segmentName, segmentId, entries, sizesByNumber, indexLength);
+            assignDataSizes(segmentName, segmentId, entries, sizesByNumber, dataLength);
+
+            Map<String, FieldPointValuesSizes> result = new LinkedHashMap<>();
+            for (FieldEntry entry : entries) {
+                FieldInfo fieldInfo = entry.fieldInfo();
+                if (fieldInfo == null) {
+                    continue;
+                }
+                FieldPointValuesSizesMutable mutable = sizesByNumber.get(fieldInfo.number);
+                if (mutable == null || !mutable.hasAnyContribution()) {
+                    continue;
+                }
+                result.put(
+                        fieldInfo.name,
+                        new FieldPointValuesSizes(mutable.metaBytes, mutable.indexBytes, mutable.dataBytes));
+            }
+
+            return result;
+        }
+
+        private void assignIndexSizes(
+                String segmentName,
+                byte[] segmentId,
+                List<FieldEntry> entries,
+                Map<Integer, FieldPointValuesSizesMutable> sizesByNumber,
+                long indexLength)
+                throws IOException {
+            String indexName = IndexFileNames.segmentFileName(segmentName, "", Lucene90PointsFormat.INDEX_EXTENSION);
+            long headerLength = readHeaderLength(indexName, INDEX_CODEC_NAME, segmentId);
+            long footerLength = CodecUtil.footerLength();
+
+            long payloadBytes = 0L;
+            for (FieldEntry entry : entries) {
+                FieldInfo fieldInfo = entry.fieldInfo();
+                if (fieldInfo == null) {
+                    continue;
+                }
+                FieldPointValuesSizesMutable mutable = sizesByNumber.get(fieldInfo.number);
+                if (mutable == null) {
+                    continue;
+                }
+                mutable.addIndexBytes(entry.metadata().packedIndexLength());
+                payloadBytes += entry.metadata().packedIndexLength();
+            }
+
+            FieldPointValuesSizesMutable first = firstMutable(entries, sizesByNumber);
+            FieldPointValuesSizesMutable last = lastMutable(entries, sizesByNumber);
+
+            if (headerLength > 0 && first != null) {
+                first.addIndexBytes(headerLength);
+            }
+            if (footerLength > 0 && last != null) {
+                last.addIndexBytes(footerLength);
+            }
+
+            long remainder = indexLength - headerLength - footerLength - payloadBytes;
+            if (remainder > 0 && first != null) {
+                first.addIndexBytes(remainder);
+            }
+        }
+
+        private void assignDataSizes(
+                String segmentName,
+                byte[] segmentId,
+                List<FieldEntry> entries,
+                Map<Integer, FieldPointValuesSizesMutable> sizesByNumber,
+                long dataLength)
+                throws IOException {
+            String dataName = IndexFileNames.segmentFileName(segmentName, "", Lucene90PointsFormat.DATA_EXTENSION);
+            long headerLength = readHeaderLength(dataName, DATA_CODEC_NAME, segmentId);
+            long footerLength = CodecUtil.footerLength();
+
+            long payloadBytes = 0L;
+            for (int i = 0; i < entries.size(); i++) {
+                FieldEntry entry = entries.get(i);
+                FieldInfo fieldInfo = entry.fieldInfo();
+                if (fieldInfo == null) {
+                    continue;
+                }
+                FieldPointValuesSizesMutable mutable = sizesByNumber.get(fieldInfo.number);
+                if (mutable == null) {
+                    continue;
+                }
+
+                long start = entry.metadata().dataStartFP();
+                long end;
+                if (i + 1 < entries.size()) {
+                    end = entries.get(i + 1).metadata().dataStartFP();
+                } else {
+                    end = dataLength - footerLength;
+                }
+                long delta = Math.max(0L, end - start);
+                mutable.addDataBytes(delta);
+                payloadBytes += delta;
+            }
+
+            FieldPointValuesSizesMutable first = firstMutable(entries, sizesByNumber);
+            FieldPointValuesSizesMutable last = lastMutable(entries, sizesByNumber);
+            if (headerLength > 0 && first != null) {
+                first.addDataBytes(headerLength);
+            }
+            if (footerLength > 0 && last != null) {
+                last.addDataBytes(footerLength);
+            }
+
+            long remainder = dataLength - headerLength - footerLength - payloadBytes;
+            if (remainder > 0 && first != null) {
+                first.addDataBytes(remainder);
+            }
+        }
+
+        private long readHeaderLength(String fileName, String codecName, byte[] segmentId) throws IOException {
+            try (IndexInput input = directory.openInput(fileName, IOContext.READONCE)) {
+                CodecUtil.checkIndexHeader(
+                        input, codecName, LUCENE90_VERSION_START, LUCENE90_VERSION_CURRENT, segmentId, "");
+                return input.getFilePointer();
+            } catch (FileNotFoundException | NoSuchFileException e) {
+                return 0L;
+            }
+        }
+
+        private Lucene90FieldMetadata readFieldMetadata(ChecksumIndexInput metaInput) throws IOException {
+            CodecUtil.checkHeader(
+                    metaInput, BKDWriter.CODEC_NAME, BKDWriter.VERSION_META_FILE, BKDWriter.VERSION_META_FILE);
+            metaInput.readVInt();
+            int numIndexDims = metaInput.readVInt();
+            metaInput.readVInt();
+            int bytesPerDim = metaInput.readVInt();
+            metaInput.readVInt();
+
+            int packedIndexBytesLength = Math.multiplyExact(numIndexDims, bytesPerDim);
+            byte[] scratch = new byte[packedIndexBytesLength];
+            metaInput.readBytes(scratch, 0, scratch.length);
+            metaInput.readBytes(scratch, 0, scratch.length);
+
+            metaInput.readVLong();
+            metaInput.readVInt();
+            int packedIndexLength = metaInput.readVInt();
+            long dataStartFP = metaInput.readLong();
+            metaInput.readLong();
+
+            return new Lucene90FieldMetadata(dataStartFP, packedIndexLength);
+        }
+
+        private FieldPointValuesSizesMutable firstMutable(
+                List<FieldEntry> entries, Map<Integer, FieldPointValuesSizesMutable> sizesByNumber) {
+            for (FieldEntry entry : entries) {
+                FieldInfo info = entry.fieldInfo();
+                if (info == null) {
+                    continue;
+                }
+                FieldPointValuesSizesMutable mutable = sizesByNumber.get(info.number);
+                if (mutable != null) {
+                    return mutable;
+                }
+            }
+            return null;
+        }
+
+        private FieldPointValuesSizesMutable lastMutable(
+                List<FieldEntry> entries, Map<Integer, FieldPointValuesSizesMutable> sizesByNumber) {
+            for (int i = entries.size() - 1; i >= 0; i--) {
+                FieldEntry entry = entries.get(i);
+                FieldInfo info = entry.fieldInfo();
+                if (info == null) {
+                    continue;
+                }
+                FieldPointValuesSizesMutable mutable = sizesByNumber.get(info.number);
+                if (mutable != null) {
+                    return mutable;
+                }
+            }
+            return null;
+        }
+    }
+
+    private record FieldEntry(FieldInfo fieldInfo, Lucene90FieldMetadata metadata) {}
+
+    private record Lucene90FieldMetadata(long dataStartFP, long packedIndexLength) {}
+
+    private static final class FieldPointValuesSizesMutable {
+        private long metaBytes;
+        private long indexBytes;
+        private long dataBytes;
+
+        private void addMetaBytes(long bytes) {
+            metaBytes += Math.max(0L, bytes);
+        }
+
+        private void addIndexBytes(long bytes) {
+            indexBytes += Math.max(0L, bytes);
+        }
+
+        private void addDataBytes(long bytes) {
+            dataBytes += Math.max(0L, bytes);
+        }
+
+        private boolean hasAnyContribution() {
+            return metaBytes > 0 || indexBytes > 0 || dataBytes > 0;
+        }
+    }
+}

--- a/src/main/java/org/commrogue/analysis/points/PointValuesAnalysisMode.java
+++ b/src/main/java/org/commrogue/analysis/points/PointValuesAnalysisMode.java
@@ -1,0 +1,30 @@
+package org.commrogue.analysis.points;
+
+import java.util.Arrays;
+
+public enum PointValuesAnalysisMode {
+    STRUCTURAL("structural"),
+    STRUCTURAL_WITH_FALLBACK("structural_with_fallback"),
+    INSTRUMENTED("instrumented");
+
+    private final String param;
+
+    PointValuesAnalysisMode(String param) {
+        this.param = param;
+    }
+
+    public static PointValuesAnalysisMode fromParam(String param) {
+        return Arrays.stream(values())
+                .filter(mode -> mode.param.equalsIgnoreCase(param))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown pointValuesAnalysisMode: " + param));
+    }
+
+    public int priority() {
+        return switch (this) {
+            case STRUCTURAL -> 0;
+            case STRUCTURAL_WITH_FALLBACK -> 1;
+            case INSTRUMENTED -> 2;
+        };
+    }
+}

--- a/src/main/java/org/commrogue/results/FieldAnalysis.java
+++ b/src/main/java/org/commrogue/results/FieldAnalysis.java
@@ -15,6 +15,7 @@ public class FieldAnalysis {
     public InvertedIndexFieldAnalysis invertedIndex;
     public KnnVectorsFieldAnalysis knnVectors;
     public DocValuesFieldAnalysis docValues;
+    public PointValuesFieldAnalysis pointValues;
     public StoredFieldsFieldAnalysis storedFields;
     //    public final AggregateSegmentReference storedField = new AggregateSegmentReference();
     //    public final AggregateSegmentReference docValues = new AggregateSegmentReference();
@@ -34,6 +35,9 @@ public class FieldAnalysis {
         if (docValues != null) {
             total += docValues.getTotalSize();
         }
+        if (pointValues != null) {
+            total += pointValues.getTotalSize();
+        }
         if (storedFields != null) {
             total += storedFields.getTotalSize();
         }
@@ -51,6 +55,9 @@ public class FieldAnalysis {
         }
         if (docValues != null) {
             map.add("doc_values", docValues.toSimpleOrderedMap());
+        }
+        if (pointValues != null) {
+            map.add("point_values", pointValues.toSimpleOrderedMap());
         }
         if (storedFields != null) {
             map.add("stored_fields", storedFields.toSimpleOrderedMap());
@@ -87,6 +94,15 @@ public class FieldAnalysis {
             mergedDocValues = DocValuesFieldAnalysis.byMerging(docValuesAnalyses);
         }
 
+        PointValuesFieldAnalysis mergedPointValues = null;
+        List<PointValuesFieldAnalysis> pointAnalyses = fieldAnalysisList.stream()
+                .map(fieldAnalysis -> fieldAnalysis.pointValues)
+                .filter(Objects::nonNull)
+                .toList();
+        if (!pointAnalyses.isEmpty()) {
+            mergedPointValues = PointValuesFieldAnalysis.byMerging(pointAnalyses);
+        }
+
         StoredFieldsFieldAnalysis mergedStoredFields = null;
         List<StoredFieldsFieldAnalysis> storedAnalyses = fieldAnalysisList.stream()
                 .map(fieldAnalysis -> fieldAnalysis.storedFields)
@@ -96,6 +112,7 @@ public class FieldAnalysis {
             mergedStoredFields = StoredFieldsFieldAnalysis.byMerging(storedAnalyses);
         }
 
-        return new FieldAnalysis(mergedInvertedIndex, mergedKnnVectors, mergedDocValues, mergedStoredFields);
+        return new FieldAnalysis(
+                mergedInvertedIndex, mergedKnnVectors, mergedDocValues, mergedPointValues, mergedStoredFields);
     }
 }

--- a/src/main/java/org/commrogue/results/PointValuesFieldAnalysis.java
+++ b/src/main/java/org/commrogue/results/PointValuesFieldAnalysis.java
@@ -1,0 +1,38 @@
+package org.commrogue.results;
+
+import java.util.Comparator;
+import java.util.List;
+import org.apache.solr.common.util.SimpleOrderedMap;
+import org.commrogue.LuceneFileExtension;
+import org.commrogue.analysis.points.PointValuesAnalysisMode;
+
+public class PointValuesFieldAnalysis extends AggregateSegmentReference {
+    public final PointValuesAnalysisMode analysisMode;
+
+    private PointValuesFieldAnalysis(
+            java.util.Map<LuceneFileExtension, Long> fileEntries, PointValuesAnalysisMode analysisMode) {
+        super(fileEntries);
+        this.analysisMode = analysisMode;
+    }
+
+    public PointValuesFieldAnalysis(PointValuesAnalysisMode analysisMode) {
+        super();
+        this.analysisMode = analysisMode;
+    }
+
+    @Override
+    public SimpleOrderedMap<Object> toSimpleOrderedMap() {
+        SimpleOrderedMap<Object> map = super.toSimpleOrderedMap();
+        map.add("analysis_mode", analysisMode.name());
+        return map;
+    }
+
+    public static PointValuesFieldAnalysis byMerging(List<PointValuesFieldAnalysis> analyses) {
+        AggregateSegmentReference merged = AggregateSegmentReference.byMergingReferences(analyses);
+        PointValuesAnalysisMode mode = analyses.stream()
+                .map(analysis -> analysis.analysisMode)
+                .max(Comparator.comparingInt(PointValuesAnalysisMode::priority))
+                .orElse(PointValuesAnalysisMode.STRUCTURAL);
+        return new PointValuesFieldAnalysis(merged.getFileEntries(), mode);
+    }
+}


### PR DESCRIPTION
## Summary
- add a point values analyzer that parses Lucene90 point metadata and assigns .kdm/.kdi/.kdd bytes per field with an instrumentation fallback
- expose configuration via a new pointValuesAnalysisMode parameter and persist results on each field
- include merged reporting utilities for point value sizes in the response structure

## Testing
- ./gradlew spotlessApply
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68cb1d216998832c8068d04555351094