### PR TITLE
Add structural estimation for term vectors

### DIFF
--- a/src/main/java/org/commrogue/IndexAnalyzerRequestHandler.java
+++ b/src/main/java/org/commrogue/IndexAnalyzerRequestHandler.java
@@ -23,6 +23,8 @@ import org.commrogue.analysis.points.PointValuesAnalysis;
 import org.commrogue.analysis.points.PointValuesAnalysisMode;
 import org.commrogue.analysis.storedfields.StoredFieldsAnalysis;
 import org.commrogue.analysis.storedfields.StoredFieldsAnalysisMode;
+import org.commrogue.analysis.termvectors.TermVectorsAnalysis;
+import org.commrogue.analysis.termvectors.TermVectorsAnalysisMode;
 import org.commrogue.lucene.Utils;
 import org.commrogue.results.IndexAnalysisResult;
 import org.commrogue.tracking.DelegatingDirectoryIndexCommit;
@@ -58,6 +60,11 @@ public class IndexAnalyzerRequestHandler extends RequestHandlerBase {
                         req.getParams().get("storedFieldsAnalysisMode"))
                 .map(StoredFieldsAnalysisMode::fromParam)
                 .orElse(StoredFieldsAnalysisMode.STRUCTURAL_WITH_FALLBACK);
+
+        TermVectorsAnalysisMode termVectorsAnalysisMode = Optional.ofNullable(
+                        req.getParams().get("termVectorsAnalysisMode"))
+                .map(TermVectorsAnalysisMode::fromParam)
+                .orElse(TermVectorsAnalysisMode.STRUCTURAL_WITH_FALLBACK);
 
         final IndexCommit originalCommit = req.getSearcher().getIndexReader().getIndexCommit();
         final TrackingReadBytesDirectory trackingDirectory =
@@ -97,6 +104,8 @@ public class IndexAnalyzerRequestHandler extends RequestHandlerBase {
                         targetDirectory, segmentReader, indexAnalysisResult, docValuesAnalysisMode));
                 analysisList.add(new PointValuesAnalysis(
                         targetDirectory, segmentReader, indexAnalysisResult, pointValuesAnalysisMode));
+                analysisList.add(new TermVectorsAnalysis(
+                        targetDirectory, segmentReader, indexAnalysisResult, termVectorsAnalysisMode));
                 analysisList.add(
                         new KnnVectorsAnalysis(targetDirectory, segmentReader, indexAnalysisResult, knnAnalysisMode));
                 analysisList.add(new StoredFieldsAnalysis(

--- a/src/main/java/org/commrogue/analysis/termvectors/TermVectorsAnalysis.java
+++ b/src/main/java/org/commrogue/analysis/termvectors/TermVectorsAnalysis.java
@@ -1,0 +1,266 @@
+package org.commrogue.analysis.termvectors;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import org.apache.lucene.index.Fields;
+import org.apache.lucene.index.PostingsEnum;
+import org.apache.lucene.index.SegmentReader;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.util.BytesRef;
+import org.commrogue.LuceneFileExtension;
+import org.commrogue.analysis.Analysis;
+import org.commrogue.results.FieldAnalysis;
+import org.commrogue.results.IndexAnalysisResult;
+import org.commrogue.results.TermVectorsFieldAnalysis;
+import org.commrogue.tracking.BytesReadTracker;
+import org.commrogue.tracking.TrackingReadBytesDirectory;
+
+public class TermVectorsAnalysis implements Analysis {
+    private final TrackingReadBytesDirectory directory;
+    private final SegmentReader segmentReader;
+    private final IndexAnalysisResult indexAnalysisResult;
+    private final TermVectorsAnalysisMode analysisMode;
+
+    public TermVectorsAnalysis(
+            TrackingReadBytesDirectory directory,
+            SegmentReader segmentReader,
+            IndexAnalysisResult indexAnalysisResult,
+            TermVectorsAnalysisMode analysisMode) {
+        this.directory = directory;
+        this.segmentReader = segmentReader;
+        this.indexAnalysisResult = indexAnalysisResult;
+        this.analysisMode = analysisMode;
+    }
+
+    @Override
+    public void analyze() throws Exception {
+        if (!segmentReader.getFieldInfos().hasVectors()) {
+            return;
+        }
+
+        TermVectorSizeEstimator estimator = new TermVectorSizeEstimator(directory, segmentReader);
+        Map<String, FieldContribution> contributions = estimator.estimate();
+        TermVectorsAnalysisMode resultMode = analysisMode == TermVectorsAnalysisMode.INSTRUMENTED
+                ? TermVectorsAnalysisMode.INSTRUMENTED
+                : TermVectorsAnalysisMode.STRUCTURAL;
+        for (Map.Entry<String, FieldContribution> entry : contributions.entrySet()) {
+            FieldAnalysis fieldAnalysis = indexAnalysisResult.getFieldAnalysis(entry.getKey());
+            TermVectorsFieldAnalysis termVectors = new TermVectorsFieldAnalysis(resultMode);
+            entry.getValue().bytesByExtension.forEach(termVectors::addTrackingByExtension);
+            fieldAnalysis.termVectors = termVectors;
+        }
+    }
+
+    private static final class TermVectorSizeEstimator {
+        private final TrackingReadBytesDirectory directory;
+        private final SegmentReader segmentReader;
+
+        private TermVectorSizeEstimator(TrackingReadBytesDirectory directory, SegmentReader segmentReader) {
+            this.directory = directory;
+            this.segmentReader = segmentReader;
+        }
+
+        private Map<String, FieldContribution> estimate() throws IOException {
+            Map<String, FieldContribution> contributions = new HashMap<>();
+            int maxDoc = segmentReader.maxDoc();
+            for (int docId = 0; docId < maxDoc; docId++) {
+                directory.resetBytesRead();
+                Fields termVectors = segmentReader.getTermVectors(docId);
+                if (termVectors == null) {
+                    continue;
+                }
+
+                Map<String, DocFieldStats> docStats = collectDocFieldStats(termVectors);
+                Map<LuceneFileExtension, Long> docBytes = collectDocBytes();
+                distributeDocBytes(docStats, docBytes, contributions);
+            }
+            return contributions;
+        }
+
+        private Map<String, DocFieldStats> collectDocFieldStats(Fields termVectors) throws IOException {
+            Map<String, DocFieldStats> statsByField = new HashMap<>();
+            Iterator<String> iterator = termVectors.iterator();
+            PostingsEnum postings = null;
+            while (iterator.hasNext()) {
+                String field = iterator.next();
+                Terms terms = termVectors.terms(field);
+                if (terms == null) {
+                    continue;
+                }
+                DocFieldStats stats = new DocFieldStats();
+                stats.hasPositions = terms.hasPositions();
+                stats.hasOffsets = terms.hasOffsets();
+                stats.hasPayloads = terms.hasPayloads();
+                TermsEnum termsEnum = terms.iterator();
+                while (termsEnum.next() != null) {
+                    BytesRef term = termsEnum.term();
+                    stats.termCount++;
+                    stats.termBytes += term.length;
+                    postings = termsEnum.postings(postings, PostingsEnum.ALL);
+                    while (postings.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+                        int freq = postings.freq();
+                        stats.totalPositions += freq;
+                        for (int i = 0; i < freq; i++) {
+                            postings.nextPosition();
+                            if (stats.hasOffsets) {
+                                postings.startOffset();
+                                postings.endOffset();
+                            }
+                            if (stats.hasPayloads) {
+                                BytesRef payload = postings.getPayload();
+                                if (payload != null) {
+                                    stats.payloadBytes += payload.length;
+                                }
+                            }
+                        }
+                    }
+                }
+                statsByField.put(field, stats);
+            }
+            return statsByField;
+        }
+
+        private Map<LuceneFileExtension, Long> collectDocBytes() {
+            Map<LuceneFileExtension, Long> bytesByExtension = new EnumMap<>(LuceneFileExtension.class);
+            for (BytesReadTracker.TrackerSummary summary : directory.summarize()) {
+                for (BytesReadTracker.TrackedSlice slice : summary.slices()) {
+                    LuceneFileExtension extension = LuceneFileExtension.fromFile(slice.sliceDescription());
+                    if (extension != LuceneFileExtension.TVD
+                            && extension != LuceneFileExtension.TVX
+                            && extension != LuceneFileExtension.TVM) {
+                        continue;
+                    }
+                    bytesByExtension.merge(extension, slice.bytesRead(), Long::sum);
+                }
+            }
+            return bytesByExtension;
+        }
+
+        private void distributeDocBytes(
+                Map<String, DocFieldStats> docStats,
+                Map<LuceneFileExtension, Long> docBytes,
+                Map<String, FieldContribution> contributions) {
+            if (docStats.isEmpty() || docBytes.isEmpty()) {
+                return;
+            }
+            Map<String, Double> weightByField = new HashMap<>();
+            for (Map.Entry<String, DocFieldStats> entry : docStats.entrySet()) {
+                DocFieldStats stats = entry.getValue();
+                double weight = stats.termBytes + stats.termCount;
+                if (stats.hasPositions) {
+                    weight += stats.totalPositions;
+                }
+                if (stats.hasOffsets) {
+                    weight += stats.totalPositions;
+                }
+                weight += stats.payloadBytes;
+                if (weight <= 0) {
+                    weight = 1.0d;
+                }
+                weightByField.put(entry.getKey(), weight);
+            }
+
+            for (String field : docStats.keySet()) {
+                FieldContribution contribution = contributions.computeIfAbsent(field, k -> new FieldContribution());
+                contribution.docCount++;
+            }
+
+            for (Map.Entry<LuceneFileExtension, Long> entry : docBytes.entrySet()) {
+                LuceneFileExtension extension = entry.getKey();
+                long totalBytes = entry.getValue();
+                Map<String, Double> weightsForExtension = weightByField;
+                if (extension == LuceneFileExtension.TVM || extension == LuceneFileExtension.TVX) {
+                    weightsForExtension = new HashMap<>();
+                    for (String field : docStats.keySet()) {
+                        weightsForExtension.put(field, 1.0d);
+                    }
+                }
+                Map<String, Long> assigned = distribute(totalBytes, weightsForExtension);
+                for (Map.Entry<String, Long> assignment : assigned.entrySet()) {
+                    FieldContribution contribution =
+                            contributions.computeIfAbsent(assignment.getKey(), k -> new FieldContribution());
+                    contribution.bytesByExtension.merge(extension, assignment.getValue(), Long::sum);
+                }
+            }
+        }
+
+        private Map<String, Long> distribute(long totalBytes, Map<String, Double> weights) {
+            Map<String, Long> result = new HashMap<>();
+            if (totalBytes <= 0 || weights.isEmpty()) {
+                return result;
+            }
+            double totalWeight =
+                    weights.values().stream().mapToDouble(Double::doubleValue).sum();
+            if (totalWeight <= 0) {
+                long perField = totalBytes / weights.size();
+                long remainder = totalBytes - perField * weights.size();
+                for (String field : weights.keySet()) {
+                    long value = perField + (remainder > 0 ? 1 : 0);
+                    if (remainder > 0) {
+                        remainder--;
+                    }
+                    result.put(field, value);
+                }
+                return result;
+            }
+            List<FieldWeight> ordered = new ArrayList<>();
+            long assigned = 0L;
+            for (Map.Entry<String, Double> entry : weights.entrySet()) {
+                double portion = (entry.getValue() / totalWeight) * totalBytes;
+                long value = (long) Math.floor(portion);
+                double fractional = portion - value;
+                ordered.add(new FieldWeight(entry.getKey(), value, fractional));
+                assigned += value;
+            }
+            long remainder = totalBytes - assigned;
+            ordered.sort((a, b) -> Double.compare(b.fractional, a.fractional));
+            for (int i = 0; i < remainder && i < ordered.size(); i++) {
+                ordered.get(i).increment();
+            }
+            for (FieldWeight weight : ordered) {
+                if (weight.value > 0) {
+                    result.put(weight.field, weight.value);
+                }
+            }
+            return result;
+        }
+
+        private static final class DocFieldStats {
+            private boolean hasPositions;
+            private boolean hasOffsets;
+            private boolean hasPayloads;
+            private long termCount;
+            private long termBytes;
+            private long totalPositions;
+            private long payloadBytes;
+        }
+
+        private static final class FieldWeight {
+            private final String field;
+            private long value;
+            private final double fractional;
+
+            private FieldWeight(String field, long value, double fractional) {
+                this.field = field;
+                this.value = value;
+                this.fractional = fractional;
+            }
+
+            private void increment() {
+                this.value++;
+            }
+        }
+    }
+
+    private static final class FieldContribution {
+        private final Map<LuceneFileExtension, Long> bytesByExtension = new EnumMap<>(LuceneFileExtension.class);
+        private long docCount;
+    }
+}

--- a/src/main/java/org/commrogue/analysis/termvectors/TermVectorsAnalysisMode.java
+++ b/src/main/java/org/commrogue/analysis/termvectors/TermVectorsAnalysisMode.java
@@ -1,0 +1,25 @@
+package org.commrogue.analysis.termvectors;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum TermVectorsAnalysisMode {
+    STRUCTURAL("structural", 2),
+    STRUCTURAL_WITH_FALLBACK("structural-with-fallback", 1),
+    INSTRUMENTED("instrumented", 0);
+
+    public final String param;
+
+    @Getter
+    private final int priority;
+
+    public static TermVectorsAnalysisMode fromParam(String param) {
+        for (TermVectorsAnalysisMode mode : values()) {
+            if (mode.param.equalsIgnoreCase(param)) {
+                return mode;
+            }
+        }
+        throw new IllegalArgumentException("Unknown term vectors analysis mode: " + param);
+    }
+}

--- a/src/main/java/org/commrogue/results/FieldAnalysis.java
+++ b/src/main/java/org/commrogue/results/FieldAnalysis.java
@@ -15,6 +15,7 @@ public class FieldAnalysis {
     public InvertedIndexFieldAnalysis invertedIndex;
     public KnnVectorsFieldAnalysis knnVectors;
     public DocValuesFieldAnalysis docValues;
+    public TermVectorsFieldAnalysis termVectors;
     public PointValuesFieldAnalysis pointValues;
     public StoredFieldsFieldAnalysis storedFields;
     //    public final AggregateSegmentReference storedField = new AggregateSegmentReference();
@@ -34,6 +35,9 @@ public class FieldAnalysis {
         }
         if (docValues != null) {
             total += docValues.getTotalSize();
+        }
+        if (termVectors != null) {
+            total += termVectors.getTotalSize();
         }
         if (pointValues != null) {
             total += pointValues.getTotalSize();
@@ -55,6 +59,9 @@ public class FieldAnalysis {
         }
         if (docValues != null) {
             map.add("doc_values", docValues.toSimpleOrderedMap());
+        }
+        if (termVectors != null) {
+            map.add("term_vectors", termVectors.toSimpleOrderedMap());
         }
         if (pointValues != null) {
             map.add("point_values", pointValues.toSimpleOrderedMap());
@@ -94,6 +101,15 @@ public class FieldAnalysis {
             mergedDocValues = DocValuesFieldAnalysis.byMerging(docValuesAnalyses);
         }
 
+        TermVectorsFieldAnalysis mergedTermVectors = null;
+        List<TermVectorsFieldAnalysis> termVectorAnalyses = fieldAnalysisList.stream()
+                .map(fieldAnalysis -> fieldAnalysis.termVectors)
+                .filter(Objects::nonNull)
+                .toList();
+        if (!termVectorAnalyses.isEmpty()) {
+            mergedTermVectors = TermVectorsFieldAnalysis.byMerging(termVectorAnalyses);
+        }
+
         PointValuesFieldAnalysis mergedPointValues = null;
         List<PointValuesFieldAnalysis> pointAnalyses = fieldAnalysisList.stream()
                 .map(fieldAnalysis -> fieldAnalysis.pointValues)
@@ -113,6 +129,11 @@ public class FieldAnalysis {
         }
 
         return new FieldAnalysis(
-                mergedInvertedIndex, mergedKnnVectors, mergedDocValues, mergedPointValues, mergedStoredFields);
+                mergedInvertedIndex,
+                mergedKnnVectors,
+                mergedDocValues,
+                mergedTermVectors,
+                mergedPointValues,
+                mergedStoredFields);
     }
 }

--- a/src/main/java/org/commrogue/results/TermVectorsFieldAnalysis.java
+++ b/src/main/java/org/commrogue/results/TermVectorsFieldAnalysis.java
@@ -1,0 +1,38 @@
+package org.commrogue.results;
+
+import java.util.Comparator;
+import java.util.List;
+import org.apache.solr.common.util.SimpleOrderedMap;
+import org.commrogue.LuceneFileExtension;
+import org.commrogue.analysis.termvectors.TermVectorsAnalysisMode;
+
+public class TermVectorsFieldAnalysis extends AggregateSegmentReference {
+    public final TermVectorsAnalysisMode analysisMode;
+
+    public TermVectorsFieldAnalysis(TermVectorsAnalysisMode analysisMode) {
+        super();
+        this.analysisMode = analysisMode;
+    }
+
+    private TermVectorsFieldAnalysis(
+            java.util.Map<LuceneFileExtension, Long> fileEntries, TermVectorsAnalysisMode analysisMode) {
+        super(fileEntries);
+        this.analysisMode = analysisMode;
+    }
+
+    @Override
+    public SimpleOrderedMap<Object> toSimpleOrderedMap() {
+        SimpleOrderedMap<Object> map = super.toSimpleOrderedMap();
+        map.add("analysis_mode", analysisMode.name());
+        return map;
+    }
+
+    public static TermVectorsFieldAnalysis byMerging(List<TermVectorsFieldAnalysis> analyses) {
+        AggregateSegmentReference merged = AggregateSegmentReference.byMergingReferences(analyses);
+        TermVectorsAnalysisMode mode = analyses.stream()
+                .map(analysis -> analysis.analysisMode)
+                .max(Comparator.comparingInt(TermVectorsAnalysisMode::getPriority))
+                .orElse(TermVectorsAnalysisMode.STRUCTURAL);
+        return new TermVectorsFieldAnalysis(merged.getFileEntries(), mode);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `TermVectorsAnalysis` to estimate per-field term vector sizes by tracking per-document I/O and distributing bytes using term statistics
- add `TermVectorsFieldAnalysis` and extend `FieldAnalysis` to report term vector results alongside other index components
- allow configuring the term vector analysis mode and run it from the request handler

## Testing
- ./gradlew spotlessApply
- ./gradlew test


------
https://chatgpt.com/codex/tasks/task_e_68cb2de7cdc0832ca3d9da53424c296d