### PR TITLE
Add Logstash indexer Helm chart

### DIFF
--- a/charts/logstash-indexer/Chart.yaml
+++ b/charts/logstash-indexer/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: logstash-indexer
+description: Helm chart for running Logstash to index Kafka events into Solr or Elasticsearch with optional data enrichment
+version: 0.1.0
+appVersion: "8.11.0"
+type: application
+keywords:
+  - logstash
+  - kafka
+  - solr
+  - elasticsearch
+  - indexing

--- a/charts/logstash-indexer/README.md
+++ b/charts/logstash-indexer/README.md
@@ -1,0 +1,88 @@
+# Logstash Indexer Helm Chart
+
+This chart deploys a Logstash instance that consumes events from Kafka, enriches them with data
+fetched from a variety of sources, and indexes the resulting documents into either Solr or
+Elasticsearch. Every part of the Logstash pipeline is rendered from `values.yaml`, so operators can
+configure behaviour declaratively without touching raw pipeline syntax.
+
+## Features
+
+* Kafka input with SASL/SSL support and pluggable codec/options.
+* Inline payload handling for events that already contain the full document.
+* Hybrid enrichment via REST APIs, MongoDB lookups, or S3 object retrieval.
+* Flexible field mapping that transforms payload fields to the exact schema expected by the target
+  index.
+* Selectable Solr (`solr_http`) or Elasticsearch output plugins with optional authentication.
+* Rich Pod customisation, including extra containers, volumes, init containers, environment
+  variables, and resource limits.
+
+## Data enrichment modes
+
+Configure the following sections under `pipeline` to control where Logstash should obtain the full
+payload for each event:
+
+* `pipeline.inline` – For events that already contain the full payload. The chart can optionally
+  parse JSON strings, move nested payloads into the canonical payload field, and even duplicate root
+  fields into the payload when only a subset of messages include inline data.
+* `pipeline.dataSources.rest` – Issues HTTP requests to retrieve additional document fields. The
+  request URL, headers, body, and response parsing (including JSON pointer extraction) are fully
+  configurable from values.
+* `pipeline.dataSources.mongo` – Uses the
+  [`logstash-filter-mongodb`](https://github.com/logstash-plugins/logstash-filter-mongodb) plugin to
+  load documents from MongoDB. Customize the query, projection, and result selection pointer.
+* `pipeline.dataSources.s3` – Downloads objects from S3 using the AWS SDK. Supports optional
+  role-assumption, JSON parsing, and pointer-based extraction.
+
+Each data source supports `matchSourceTypes` (values read from `pipeline.sourceTypeField`) so that
+individual events can declare how they should be enriched. Hybrid workflows are supported by
+allowing events to fall back to inline payloads whenever they exist.
+
+> **Note:** Fetching from MongoDB and Solr requires the corresponding Logstash plugins
+> (`logstash-filter-mongodb` and `logstash-output-solr_http`). S3 enrichment depends on the
+> `aws-sdk-s3` (and optionally `aws-sdk-sts`) Ruby gems. Install any required plugins by supplying
+> `extraInitContainers` that run `logstash-plugin install ...` or by extending the Logstash image.
+
+## Field mappings
+
+`pipeline.fieldMappings` describes how to transform payload fields into the final document that will
+be sent to Solr or Elasticsearch. The simplest form is a map where keys are the source field names
+from the payload and values are the destination field names:
+
+```yaml
+pipeline:
+  fieldMappings:
+    title: title_s
+    body: body_txt
+```
+
+When more control is needed, assign an object with `target`, optional `sourcePath` (to read from a
+nested payload path), and `keepSource` to retain the original field after mapping.
+
+```yaml
+pipeline:
+  fieldMappings:
+    summary:
+      target: summary_t
+      sourcePath: payload.metadata.summary
+      keepSource: true
+```
+
+## Outputs
+
+Select the target indexer via `output.type` (`elasticsearch` or `solr`). Each block exposes the most
+commonly used settings, including credentials that are sourced from Kubernetes Secrets via helper
+environment variables. Additional raw Logstash outputs can be appended by populating
+`output.extraOutputs`.
+
+## Installing the chart
+
+Add the chart to your manifests (for example within a Git repository) and customise `values.yaml` to
+match your Kafka, enrichment, and indexing requirements. Once ready, render or install the chart
+with Helm:
+
+```bash
+helm install logstash-indexer ./charts/logstash-indexer -f my-values.yaml
+```
+
+Run `helm template` to inspect the generated Kubernetes manifests and Logstash pipeline before
+applying them to a cluster.

--- a/charts/logstash-indexer/templates/_helpers.tpl
+++ b/charts/logstash-indexer/templates/_helpers.tpl
@@ -1,0 +1,140 @@
+{{- define "logstash-indexer.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "logstash-indexer.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "logstash-indexer.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version -}}
+{{- end -}}
+
+{{- define "logstash-indexer.labels" -}}
+helm.sh/chart: {{ include "logstash-indexer.chart" . }}
+{{ include "logstash-indexer.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{- end -}}
+
+{{- define "logstash-indexer.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "logstash-indexer.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "logstash-indexer.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{ default (include "logstash-indexer.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+{{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{- define "logstash-indexer.toFieldRef" -}}
+{{- $field := . | default "" -}}
+{{- if eq $field "" -}}
+{{- "" -}}
+{{- else if hasPrefix $field "[" -}}
+{{- $field -}}
+{{- else -}}
+{{- $normalized := regexReplaceAll "\\." $field "][" -}}
+[{{ $normalized }}]
+{{- end -}}
+{{- end -}}
+
+{{- define "logstash-indexer.appendField" -}}
+{{- $base := include "logstash-indexer.toFieldRef" .base -}}
+{{- $fieldRef := include "logstash-indexer.toFieldRef" .field -}}
+{{- if eq $base "" -}}
+{{- $fieldRef -}}
+{{- else if eq $fieldRef "" -}}
+{{- $base -}}
+{{- else -}}
+{{- $trimmed := trimSuffix "]" (trimPrefix "[" $fieldRef) -}}
+{{ printf "%s[%s]" $base $trimmed }}
+{{- end -}}
+{{- end -}}
+
+{{- define "logstash-indexer.renderValue" -}}
+{{- $v := . -}}
+{{- if kindIs "string" $v -}}
+"{{ $v }}"
+{{- else if kindIs "bool" $v -}}
+{{- if $v }}true{{ else }}false{{ end -}}
+{{- else if or (kindIs "int64" $v) (kindIs "float64" $v) (kindIs "float32" $v) (kindIs "int" $v) -}}
+{{ $v }}
+{{- else if kindIs "slice" $v -}}
+[{{- $first := true -}}{{- range $item := $v -}}{{- if $first -}}{{- $first = false -}}{{ else }}, {{ end -}}{{ include "logstash-indexer.renderValue" $item }}{{- end -}}]
+{{- else if kindIs "map" $v -}}
+{{- include "logstash-indexer.renderHash" $v -}}
+{{- else -}}
+"{{ $v }}"
+{{- end -}}
+{{- end -}}
+
+{{- define "logstash-indexer.renderHash" -}}
+{{- $map := . -}}
+{{- if $map }}
+{ {{- $first := true -}}{{- range $k, $val := $map -}}{{- if $first -}}{{- $first = false -}}{{ else }}, {{ end -}}"{{ $k }}" => {{ include "logstash-indexer.renderValue" $val }}{{- end -}} }
+{{- else -}}
+{ }
+{{- end -}}
+{{- end -}}
+
+{{- define "logstash-indexer.renderList" -}}
+[{{- $first := true -}}{{- range $item := . -}}{{- if $first -}}{{- $first = false -}}{{ else }}, {{ end -}}{{ include "logstash-indexer.renderValue" $item }}{{- end -}}]
+{{- end -}}
+
+{{- define "logstash-indexer.fieldPresenceCondition" -}}
+{{- $fields := . | default (list) -}}
+{{- $first := true -}}
+{{- range $field := $fields -}}
+{{- $ref := include "logstash-indexer.toFieldRef" $field -}}
+{{- if $ref }}
+{{- if $first -}}{{- $first = false -}}{{ else }} and {{ end -}}{{ $ref }}
+{{- end -}}
+{{- end -}}
+{{- if $first }}false{{- end -}}
+{{- end -}}
+
+{{- define "logstash-indexer.sourceTypeCondition" -}}
+{{- $field := include "logstash-indexer.toFieldRef" .field -}}
+{{- $values := .values | default (list) -}}
+{{- if and $field (gt (len $values) 0) -}}
+{{- $first := true -}}
+{{- range $val := $values -}}
+{{- if ne (printf "%v" $val) "" -}}
+{{- if $first -}}{{- $first = false -}}{{ else }} or {{ end -}}{{ printf "%s == \"%s\"" $field $val }}
+{{- end -}}
+{{- end -}}
+{{- if $first }}false{{- end -}}
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{- define "logstash-indexer.renderSecretEnv" -}}
+{{- $cfg := . -}}
+{{- if and $cfg.envVar (or $cfg.value (and $cfg.existingSecret $cfg.key)) }}
+- name: {{ $cfg.envVar }}
+  {{- if $cfg.value }}
+  value: {{ $cfg.value | quote }}
+  {{- else }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $cfg.existingSecret }}
+      key: {{ $cfg.key }}
+  {{- end }}
+{{- end -}}
+{{- end -}}

--- a/charts/logstash-indexer/templates/configmap-config.yaml
+++ b/charts/logstash-indexer/templates/configmap-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "logstash-indexer.fullname" . }}-config
+  labels:
+    {{- include "logstash-indexer.labels" . | nindent 4 }}
+data:
+{{- range $name, $content := .Values.logstashConfig }}
+  {{ $name }}: |
+{{ tpl $content $ | indent 4 }}
+{{- end }}

--- a/charts/logstash-indexer/templates/configmap-pipeline.yaml
+++ b/charts/logstash-indexer/templates/configmap-pipeline.yaml
@@ -1,0 +1,542 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "logstash-indexer.fullname" . }}-pipeline
+  labels:
+    {{- include "logstash-indexer.labels" . | nindent 4 }}
+data:
+  logstash.conf: |
+    {{- $payloadFieldRaw := include "logstash-indexer.toFieldRef" .Values.pipeline.payloadField -}}
+    {{- $payloadField := $payloadFieldRaw -}}
+    {{- if eq $payloadField "" }}
+    {{- $payloadField = "[payload]" -}}
+    {{- end }}
+    {{- $mappingRaw := default (dict) .Values.pipeline.fieldMappings -}}
+    {{- $mappingEntries := list -}}
+    {{- range $source, $cfg := $mappingRaw }}
+    {{- $entry := dict "sourceName" $source "targetName" "" "sourcePath" "" "targetPath" "" "keepSource" false -}}
+    {{- if kindIs "string" $cfg }}
+    {{- $_ := set $entry "targetName" $cfg -}}
+    {{- else if kindIs "map" $cfg }}
+    {{- if hasKey $cfg "target" }}{{- $_ := set $entry "targetName" (index $cfg "target") -}}{{- end -}}
+    {{- if hasKey $cfg "source" }}{{- $_ := set $entry "sourceName" (index $cfg "source") -}}{{- end -}}
+    {{- if hasKey $cfg "sourcePath" }}{{- $_ := set $entry "sourcePath" (index $cfg "sourcePath") -}}{{- end -}}
+    {{- if hasKey $cfg "keepSource" }}{{- $_ := set $entry "keepSource" (index $cfg "keepSource") -}}{{- end -}}
+    {{- end -}}
+    {{- if eq (index $entry "sourcePath") "" }}
+    {{- $_ := set $entry "sourcePath" (include "logstash-indexer.appendField" (dict "base" $payloadField "field" (index $entry "sourceName"))) -}}
+    {{- else -}}
+    {{- $_ := set $entry "sourcePath" (include "logstash-indexer.toFieldRef" (index $entry "sourcePath")) -}}
+    {{- end -}}
+    {{- if eq (index $entry "targetName") "" }}
+    {{- $_ := set $entry "targetName" (index $entry "sourceName") -}}
+    {{- end -}}
+    {{- $_ := set $entry "targetPath" (include "logstash-indexer.toFieldRef" (index $entry "targetName")) -}}
+    {{- $mappingEntries = append $mappingEntries $entry -}}
+    {{- end -}}
+    {{- $inlineWhitelist := .Values.pipeline.inline.rootFieldWhitelist | default (list) -}}
+    {{- $inlineRootFields := ternary $inlineWhitelist (keys $mappingRaw) (gt (len $inlineWhitelist) 0) -}}
+    {{- $inlinePayloadField := include "logstash-indexer.toFieldRef" .Values.pipeline.inline.payloadField -}}
+    {{- $inlineSourceCondition := include "logstash-indexer.sourceTypeCondition" (dict "field" .Values.pipeline.sourceTypeField "values" .Values.pipeline.inline.matchSourceTypes) -}}
+    {{- $inlineCondition := "" -}}
+    {{- if ne $inlineSourceCondition "false" }}
+    {{- $inlineCondition = printf "(%s)" $inlineSourceCondition -}}
+    {{- end -}}
+    {{- if ne $inlinePayloadField "" }}
+    {{- if ne $inlineCondition "" -}}
+    {{- $inlineCondition = printf "%s or %s" $inlineCondition $inlinePayloadField -}}
+    {{- else -}}
+    {{- $inlineCondition = $inlinePayloadField -}}
+    {{- end -}}
+    {{- end -}}
+    {{- if eq $inlineCondition "" }}
+    {{- $inlineCondition = "false" -}}
+    {{- end -}}
+    {{- $payloadExistsCondition := $payloadField -}}
+    {{- $payloadMissingCondition := printf "!%s" $payloadField -}}
+    input {
+      kafka {
+        bootstrap_servers => "{{ join "," .Values.pipeline.kafka.bootstrapServers }}"
+        topics => {{ include "logstash-indexer.renderList" .Values.pipeline.kafka.topics }}
+        group_id => "{{ .Values.pipeline.kafka.groupId }}"
+        {{- if .Values.pipeline.kafka.clientId }}
+        client_id => "{{ .Values.pipeline.kafka.clientId }}"
+        {{- end }}
+        {{- if .Values.pipeline.kafka.autoOffsetReset }}
+        auto_offset_reset => "{{ .Values.pipeline.kafka.autoOffsetReset }}"
+        {{- end }}
+        {{- if .Values.pipeline.kafka.securityProtocol }}
+        security_protocol => "{{ .Values.pipeline.kafka.securityProtocol }}"
+        {{- end }}
+        {{- if .Values.pipeline.kafka.decorateEvents }}
+        decorate_events => true
+        {{- end }}
+        {{- if gt (int .Values.pipeline.kafka.consumerThreads) 1 }}
+        consumer_threads => {{ .Values.pipeline.kafka.consumerThreads }}
+        {{- end }}
+        {{- if .Values.pipeline.kafka.codec }}
+        codec => {{ .Values.pipeline.kafka.codec }}
+        {{- end }}
+        {{- if .Values.pipeline.kafka.sasl.enabled }}
+        sasl_mechanism => "{{ .Values.pipeline.kafka.sasl.mechanism }}"
+        sasl_plain_username => "{{ .Values.pipeline.kafka.sasl.username }}"
+        sasl_plain_password => "${{{ .Values.pipeline.kafka.sasl.password.envVar }}}"
+        {{- end }}
+        {{- if .Values.pipeline.kafka.ssl.enabled }}
+        ssl => true
+        {{- if .Values.pipeline.kafka.ssl.truststore }}
+        ssl_truststore_location => "{{ .Values.pipeline.kafka.ssl.truststore }}"
+        {{- end }}
+        {{- if .Values.pipeline.kafka.ssl.truststorePassword.envVar }}
+        ssl_truststore_password => "${{{ .Values.pipeline.kafka.ssl.truststorePassword.envVar }}}"
+        {{- end }}
+        {{- if .Values.pipeline.kafka.ssl.keystore }}
+        ssl_keystore_location => "{{ .Values.pipeline.kafka.ssl.keystore }}"
+        {{- end }}
+        {{- if .Values.pipeline.kafka.ssl.keystorePassword.envVar }}
+        ssl_keystore_password => "${{{ .Values.pipeline.kafka.ssl.keystorePassword.envVar }}}"
+        {{- end }}
+        {{- if not .Values.pipeline.kafka.ssl.verify }}
+        ssl_endpoint_identification_algorithm => ""
+        {{- end }}
+        {{- end }}
+        {{- range $key, $val := .Values.pipeline.kafka.additionalOptions }}
+        {{ $key }} => {{ include "logstash-indexer.renderValue" $val }}
+        {{- end }}
+      }
+    }
+
+    filter {
+      {{- if .Values.pipeline.staticFields }}
+      ruby {
+        id => "static-fields"
+        code => '
+          static_data = LogStash::Json.load({{ toJson .Values.pipeline.staticFields | quote }})
+          static_data.each do |k, v|
+            event.set(k, v) unless event.get(k)
+          end
+        '
+      }
+      {{- end }}
+
+      {{- if and .Values.pipeline.inline.enabled (ne $inlineCondition "false") }}
+      if {{ $inlineCondition }} {
+        ruby {
+          id => "inline-payload"
+          code => '
+            payload_field = {{ include "logstash-indexer.toFieldRef" .Values.pipeline.inline.payloadField | quote }}
+            target_field = {{ $payloadField | quote }}
+            payload = nil
+            if !payload_field.empty?
+              payload = event.get(payload_field)
+            end
+            if payload.is_a?(String) && {{ if .Values.pipeline.inline.payloadIsJsonString }}true{{ else }}false{{ end }}
+              begin
+                payload = LogStash::Json.load(payload)
+              rescue => e
+                event.tag("inline_payload_parse_failure")
+                payload = nil
+              end
+            end
+            if payload.nil? && {{ if .Values.pipeline.inline.fallbackToRootFields }}true{{ else }}false{{ end }}
+              data = {}
+              {{- if gt (len $inlineRootFields) 0 }}
+              {{- range $field := $inlineRootFields }}
+              value = event.get({{ include "logstash-indexer.toFieldRef" $field | quote }})
+              data[{{ $field | quote }}] = value unless value.nil?
+              {{- end }}
+              {{- end }}
+              payload = data unless data.empty?
+            end
+            if payload.is_a?(Hash)
+              event.set(target_field, payload)
+            end
+          '
+        }
+        {{- if and .Values.pipeline.inline.removeSourceAfterExtract (ne $inlinePayloadField "") }}
+        mutate {
+          remove_field => [{{ include "logstash-indexer.renderValue" (include "logstash-indexer.toFieldRef" .Values.pipeline.inline.payloadField) }}]
+        }
+        {{- end }}
+      }
+      {{- end }}
+
+      {{- $rest := .Values.pipeline.dataSources.rest -}}
+      {{- if $rest.enabled }}
+      if ({{ include "logstash-indexer.sourceTypeCondition" (dict "field" .Values.pipeline.sourceTypeField "values" $rest.matchSourceTypes) }}{{- if eq $rest.fetchCondition "missingPayload" }} and {{ $payloadMissingCondition }}{{- end }}) {
+        http {
+          id => "rest-fetch"
+          url => "{{ $rest.request.urlTemplate }}"
+          verb => "{{ default "get" (lower $rest.request.method) }}"
+          target_body => "[@metadata][rest_lookup][body]"
+          target_headers => "[@metadata][rest_lookup][headers]"
+          target_status_code => "[@metadata][rest_lookup][status]"
+          {{- if $rest.request.headers }}
+          headers => {{ include "logstash-indexer.renderHash" $rest.request.headers }}
+          {{- end }}
+          {{- if $rest.request.params }}
+          params => {{ include "logstash-indexer.renderHash" $rest.request.params }}
+          {{- end }}
+          {{- if $rest.request.body }}
+          body => "{{ $rest.request.body }}"
+          {{- end }}
+          {{- if gt (int $rest.request.timeoutSeconds) 0 }}
+          connect_timeout => {{ $rest.request.timeoutSeconds }}
+          {{- end }}
+          {{- if $rest.request.proxy }}
+          proxy => "{{ $rest.request.proxy }}"
+          {{- end }}
+        }
+        ruby {
+          id => "rest-parse"
+          code => '
+            raw = event.get("[@metadata][rest_lookup][body]")
+            success = false
+            data = nil
+            if raw
+              begin
+                case {{ default "json" $rest.response.format | quote }}
+                when "json"
+                  parsed = raw
+                  if parsed.is_a?(String)
+                    parsed = LogStash::Json.load(parsed)
+                  end
+                  pointer = {{ default "" $rest.response.jsonPointer | quote }}
+                  unless pointer.nil? || pointer.empty?
+                    segments = pointer.split("/").reject(&:empty?)
+                    segments.each do |segment|
+                      if parsed.is_a?(Hash)
+                        parsed = parsed[segment]
+                      elsif parsed.is_a?(Array)
+                        idx = segment =~ /^\d+$/ ? segment.to_i : nil
+                        parsed = idx ? parsed[idx] : nil
+                      else
+                        parsed = nil
+                      end
+                      break if parsed.nil?
+                    end
+                  end
+                  data = parsed
+                else
+                  data = raw
+                end
+              rescue => e
+                event.tag("rest_response_parse_failure")
+              end
+            end
+            target_field = {{ default $payloadField (include "logstash-indexer.toFieldRef" $rest.response.targetField) | quote }}
+            if data.is_a?(Hash)
+              existing = event.get(target_field)
+              if existing.is_a?(Hash) && {{ eq $rest.mergeStrategy "merge" }}
+                event.set(target_field, existing.merge(data))
+              else
+                event.set(target_field, data)
+              end
+              success = true
+            elsif !data.nil?
+              event.set(target_field, data)
+              success = true
+            end
+            event.set("[@metadata][rest_lookup][success]", success)
+          '
+        }
+        {{- if $rest.response.statusField }}
+        mutate {
+          rename => { "[@metadata][rest_lookup][status]" => {{ include "logstash-indexer.toFieldRef" $rest.response.statusField }} }
+        }
+        {{- end }}
+        if ![@metadata][rest_lookup][success] {
+          mutate { add_tag => ["rest_lookup_failed"] }
+          {{- if not $rest.allowFailure }}
+          drop { }
+          {{- end }}
+        }
+      }
+      {{- end }}
+
+      {{- $mongo := .Values.pipeline.dataSources.mongo -}}
+      {{- if $mongo.enabled }}
+      if ({{ include "logstash-indexer.sourceTypeCondition" (dict "field" .Values.pipeline.sourceTypeField "values" $mongo.matchSourceTypes) }}{{- if eq $mongo.fetchCondition "missingPayload" }} and {{ $payloadMissingCondition }}{{- end }}) {
+        mongodb {
+          id => "mongo-fetch"
+          uri => "{{ $mongo.uri }}"
+          database => "{{ $mongo.database }}"
+          collection => "{{ $mongo.collection }}"
+          filter => {{ $mongo.queryTemplate | quote }}
+          {{- if $mongo.projection }}
+          projection => {{ $mongo.projection | quote }}
+          {{- end }}
+          target => "[@metadata][mongo_lookup][results]"
+        }
+        ruby {
+          id => "mongo-merge"
+          code => '
+            data = event.get("[@metadata][mongo_lookup][results]")
+            if data.is_a?(Array)
+              data = data.first
+            end
+            pointer = {{ default "" $mongo.resultSelector | quote }}
+            unless pointer.nil? || pointer.empty?
+              begin
+                segments = pointer.split("/").reject(&:empty?)
+                segments.each do |segment|
+                  if data.is_a?(Hash)
+                    data = data[segment]
+                  elsif data.is_a?(Array)
+                    idx = segment =~ /^\d+$/ ? segment.to_i : nil
+                    data = idx ? data[idx] : nil
+                  else
+                    data = nil
+                  end
+                  break if data.nil?
+                end
+              rescue => e
+                event.tag("mongo_result_parse_failure")
+                data = nil
+              end
+            end
+            success = false
+            target_field = {{ default $payloadField (include "logstash-indexer.toFieldRef" $mongo.targetField) | quote }}
+            if data.is_a?(Hash)
+              existing = event.get(target_field)
+              if existing.is_a?(Hash) && {{ eq $mongo.mergeStrategy "merge" }}
+                event.set(target_field, existing.merge(data))
+              else
+                event.set(target_field, data)
+              end
+              success = true
+            elsif !data.nil?
+              event.set(target_field, data)
+              success = true
+            end
+            event.set("[@metadata][mongo_lookup][success]", success)
+          '
+        }
+        if ![@metadata][mongo_lookup][success] {
+          mutate { add_tag => ["mongo_lookup_failed"] }
+          {{- if not $mongo.allowFailure }}
+          drop { }
+          {{- end }}
+        }
+      }
+      {{- end }}
+
+      {{- $s3 := .Values.pipeline.dataSources.s3 -}}
+      {{- if $s3.enabled }}
+      if ({{ include "logstash-indexer.sourceTypeCondition" (dict "field" .Values.pipeline.sourceTypeField "values" $s3.matchSourceTypes) }}{{- if eq $s3.fetchCondition "missingPayload" }} and {{ $payloadMissingCondition }}{{- end }}) {
+        ruby {
+          id => "s3-fetch"
+          code => '
+            require "aws-sdk-s3"
+            {{- if $s3.assumeRoleArn }}
+            require "aws-sdk-sts"
+            {{- end }}
+            bucket = event.sprintf("{{ $s3.bucket }}")
+            key = event.sprintf("{{ $s3.keyTemplate }}")
+            version_field = {{ default "" $s3.versionIdField | quote }}
+            version_id = version_field.empty? ? nil : event.get(version_field)
+            client_options = LogStash::Json.load({{ toJson $s3.clientOptions | quote }})
+            region = {{ $s3.region | quote }}
+            unless client_options.is_a?(Hash)
+              client_options = {}
+            else
+              sym_client_options = {}
+              client_options.each do |k, v|
+                sym_client_options[k.to_sym] = v
+              end
+              client_options = sym_client_options
+            end
+            client_options[:region] = region unless region.empty?
+            success = false
+            begin
+              {{- if $s3.assumeRoleArn }}
+              sts = Aws::STS::Client.new(client_options)
+              assumed = sts.assume_role(role_arn: {{ $s3.assumeRoleArn | quote }}, role_session_name: "logstash-indexer")
+              creds = assumed.credentials
+              client_options[:credentials] = Aws::Credentials.new(creds.access_key_id, creds.secret_access_key, creds.session_token)
+              {{- end }}
+              client = Aws::S3::Client.new(client_options)
+              params = { bucket: bucket, key: key }
+              params[:version_id] = version_id unless version_id.nil? || version_id == ""
+              response = client.get_object(params)
+              body = response.body.read
+              data = nil
+              if {{ eq $s3.contentFormat "json" }}
+                begin
+                  data = LogStash::Json.load(body)
+                rescue => e
+                  event.tag("s3_response_parse_failure")
+                end
+              else
+                data = body
+              end
+              pointer = {{ default "" $s3.jsonPointer | quote }}
+              unless data.nil? || pointer.nil? || pointer.empty?
+                begin
+                  segments = pointer.split("/").reject(&:empty?)
+                  segments.each do |segment|
+                    if data.is_a?(Hash)
+                      data = data[segment]
+                    elsif data.is_a?(Array)
+                      idx = segment =~ /^\d+$/ ? segment.to_i : nil
+                      data = idx ? data[idx] : nil
+                    else
+                      data = nil
+                    end
+                    break if data.nil?
+                  end
+                rescue => e
+                  event.tag("s3_pointer_failure")
+                  data = nil
+                end
+              end
+              target_field = {{ default $payloadField (include "logstash-indexer.toFieldRef" $s3.targetField) | quote }}
+              if data.is_a?(Hash)
+                existing = event.get(target_field)
+                if existing.is_a?(Hash) && {{ eq $s3.mergeStrategy "merge" }}
+                  event.set(target_field, existing.merge(data))
+                else
+                  event.set(target_field, data)
+                end
+                success = true
+              elsif !data.nil?
+                event.set(target_field, data)
+                success = true
+              end
+            rescue => e
+              event.tag("s3_lookup_error")
+            end
+            event.set("[@metadata][s3_lookup][success]", success)
+          '
+        }
+        if ![@metadata][s3_lookup][success] {
+          mutate { add_tag => ["s3_lookup_failed"] }
+          {{- if not $s3.allowFailure }}
+          drop { }
+          {{- end }}
+        }
+      }
+      {{- end }}
+
+      {{- if gt (len $mappingEntries) 0 }}
+      mutate {
+        rename => {
+{{- range $entry := $mappingEntries }}
+          "{{ index $entry "sourcePath" }}" => "{{ index $entry "targetPath" }}"
+{{- end }}
+        }
+      }
+      {{- end }}
+
+      {{- if and .Values.pipeline.removeMappedSourceFields (gt (len $mappingEntries) 0) }}
+      {{- $mappedSources := list -}}
+      {{- range $entry := $mappingEntries }}
+        {{- $sourceRef := include "logstash-indexer.toFieldRef" (index $entry "sourceName") -}}
+        {{- if and (not (index $entry "keepSource")) (ne $sourceRef (index $entry "targetPath")) }}
+          {{- $mappedSources = append $mappedSources $sourceRef -}}
+        {{- end -}}
+      {{- end }}
+      {{- if gt (len $mappedSources) 0 }}
+      mutate {
+        remove_field => {{ include "logstash-indexer.renderList" $mappedSources }}
+      }
+      {{- end }}
+      {{- end }}
+
+      {{- $removeList := list -}}
+      {{- if and (ne $payloadField "") (not .Values.pipeline.keepPayloadField) }}
+      {{- $removeList = append $removeList $payloadField -}}
+      {{- end }}
+      {{- range $field := .Values.pipeline.removeFields }}
+      {{- $removeList = append $removeList (include "logstash-indexer.toFieldRef" $field) -}}
+      {{- end }}
+      {{- if gt (len $removeList) 0 }}
+      mutate {
+        remove_field => {{ include "logstash-indexer.renderList" $removeList }}
+      }
+      {{- end }}
+
+      {{- if .Values.pipeline.additionalFilters }}
+{{- range $filter := .Values.pipeline.additionalFilters }}
+      {{ $filter }}
+{{- end }}
+      {{- end }}
+
+      {{- if and .Values.pipeline.tagMissingPayload (ne $payloadField "") }}
+      if !({{ $payloadExistsCondition }}) {
+        mutate { add_tag => ["missing_payload"] }
+        {{- if .Values.pipeline.dropOnMissingPayload }}
+        drop { }
+        {{- end }}
+      }
+      {{- end }}
+    }
+
+    output {
+      {{- if eq .Values.output.type "solr" }}
+      solr_http {
+        url => "{{ .Values.output.solr.url }}"
+        {{- if .Values.output.solr.collection }}
+        collection => "{{ .Values.output.solr.collection }}"
+        {{- end }}
+        {{- if .Values.output.solr.commitWithin }}
+        commit_within => {{ .Values.output.solr.commitWithin }}
+        {{- end }}
+        {{- if .Values.output.solr.softCommit }}
+        soft_commit => true
+        {{- end }}
+        {{- if .Values.output.solr.skipCommit }}
+        skip_commit => true
+        {{- end }}
+        {{- if .Values.output.solr.user }}
+        user => "{{ .Values.output.solr.user }}"
+        {{- end }}
+        {{- if .Values.output.solr.password.envVar }}
+        password => "${{{ .Values.output.solr.password.envVar }}}"
+        {{- end }}
+        {{- range $key, $val := .Values.output.solr.additionalOptions }}
+        {{ $key }} => {{ include "logstash-indexer.renderValue" $val }}
+        {{- end }}
+      }
+      {{- else }}
+      elasticsearch {
+        hosts => {{ include "logstash-indexer.renderList" .Values.output.elasticsearch.hosts }}
+        index => "{{ .Values.output.elasticsearch.index }}"
+        {{- $docIdRef := include "logstash-indexer.toFieldRef" .Values.output.elasticsearch.documentIdField -}}
+        {{- if ne $docIdRef "" }}
+        document_id => "{{ printf "%%{%s}" $docIdRef }}"
+        {{- end }}
+        action => "{{ .Values.output.elasticsearch.action }}"
+        {{- if .Values.output.elasticsearch.user }}
+        user => "{{ .Values.output.elasticsearch.user }}"
+        {{- end }}
+        {{- if .Values.output.elasticsearch.password.envVar }}
+        password => "${{{ .Values.output.elasticsearch.password.envVar }}}"
+        {{- end }}
+        {{- if .Values.output.elasticsearch.apiKey.envVar }}
+        api_key => "${{{ .Values.output.elasticsearch.apiKey.envVar }}}"
+        {{- end }}
+        {{- if .Values.output.elasticsearch.manageTemplate | not }}
+        manage_template => false
+        {{- end }}
+        {{- if .Values.output.elasticsearch.dataStream.enabled }}
+        data_stream => {{ include "logstash-indexer.renderHash" .Values.output.elasticsearch.dataStream }}
+        {{- end }}
+        {{- if .Values.output.elasticsearch.ssl.enabled }}
+        ssl => true
+        {{- if .Values.output.elasticsearch.ssl.certificateAuthority }}
+        cacert => "{{ .Values.output.elasticsearch.ssl.certificateAuthority }}"
+        {{- end }}
+        {{- if not .Values.output.elasticsearch.ssl.verify }}
+        ssl_certificate_verification => false
+        {{- end }}
+        {{- end }}
+        {{- range $key, $val := .Values.output.elasticsearch.additionalOptions }}
+        {{ $key }} => {{ include "logstash-indexer.renderValue" $val }}
+        {{- end }}
+      }
+      {{- end }}
+{{- range $extra := .Values.output.extraOutputs }}
+      {{ $extra }}
+{{- end }}
+    }

--- a/charts/logstash-indexer/templates/deployment.yaml
+++ b/charts/logstash-indexer/templates/deployment.yaml
@@ -1,0 +1,127 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "logstash-indexer.fullname" . }}
+  labels:
+    {{- include "logstash-indexer.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "logstash-indexer.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "logstash-indexer.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "logstash-indexer.serviceAccountName" . }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- range . }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.extraInitContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: logstash
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- $kafkaSaslEnv := include "logstash-indexer.renderSecretEnv" .Values.pipeline.kafka.sasl.password -}}
+          {{- $kafkaTruststoreEnv := include "logstash-indexer.renderSecretEnv" .Values.pipeline.kafka.ssl.truststorePassword -}}
+          {{- $kafkaKeystoreEnv := include "logstash-indexer.renderSecretEnv" .Values.pipeline.kafka.ssl.keystorePassword -}}
+          {{- $esPasswordEnv := include "logstash-indexer.renderSecretEnv" .Values.output.elasticsearch.password -}}
+          {{- $esApiKeyEnv := include "logstash-indexer.renderSecretEnv" .Values.output.elasticsearch.apiKey -}}
+          {{- $solrPasswordEnv := include "logstash-indexer.renderSecretEnv" .Values.output.solr.password -}}
+          {{- $hasEnv := or (ne $kafkaSaslEnv "") (ne $kafkaTruststoreEnv "") (ne $kafkaKeystoreEnv "") (ne $esPasswordEnv "") (ne $esApiKeyEnv "") (ne $solrPasswordEnv "") (gt (len .Values.extraEnv) 0) -}}
+          {{- if $hasEnv }}
+          env:
+            {{- if ne $kafkaSaslEnv "" }}
+{{ $kafkaSaslEnv | indent 12 }}
+            {{- end }}
+            {{- if ne $kafkaTruststoreEnv "" }}
+{{ $kafkaTruststoreEnv | indent 12 }}
+            {{- end }}
+            {{- if ne $kafkaKeystoreEnv "" }}
+{{ $kafkaKeystoreEnv | indent 12 }}
+            {{- end }}
+            {{- if ne $esPasswordEnv "" }}
+{{ $esPasswordEnv | indent 12 }}
+            {{- end }}
+            {{- if ne $esApiKeyEnv "" }}
+{{ $esApiKeyEnv | indent 12 }}
+            {{- end }}
+            {{- if ne $solrPasswordEnv "" }}
+{{ $solrPasswordEnv | indent 12 }}
+            {{- end }}
+            {{- range .Values.extraEnv }}
+{{ toYaml . | indent 12 }}
+            {{- end }}
+          {{- end }}
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
+{{ toYaml . | indent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /usr/share/logstash/config/logstash.yml
+              subPath: logstash.yml
+            - name: config
+              mountPath: /usr/share/logstash/config/pipelines.yml
+              subPath: pipelines.yml
+            - name: pipeline
+              mountPath: /usr/share/logstash/pipeline/logstash.conf
+              subPath: logstash.conf
+            {{- range .Values.extraVolumeMounts }}
+{{ toYaml . | indent 12 }}
+            {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- with .Values.extraContainers }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "logstash-indexer.fullname" . }}-config
+        - name: pipeline
+          configMap:
+            name: {{ include "logstash-indexer.fullname" . }}-pipeline
+{{- range .Values.extraVolumes }}
+{{ toYaml . | indent 8 }}
+{{- end }}

--- a/charts/logstash-indexer/templates/service.yaml
+++ b/charts/logstash-indexer/templates/service.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.service.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "logstash-indexer.fullname" . }}
+  labels:
+    {{- include "logstash-indexer.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "logstash-indexer.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/logstash-indexer/templates/serviceaccount.yaml
+++ b/charts/logstash-indexer/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "logstash-indexer.serviceAccountName" . }}
+  labels:
+    {{- include "logstash-indexer.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- if hasKey .Values.serviceAccount "automount" }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}
+{{- end }}

--- a/charts/logstash-indexer/values.yaml
+++ b/charts/logstash-indexer/values.yaml
@@ -1,0 +1,271 @@
+# Default values for the Logstash indexer chart.
+#
+# The chart renders an opinionated Logstash pipeline that consumes Kafka events and optionally
+# enriches them by pulling additional fields from REST APIs, MongoDB, or S3 before indexing into
+# Solr or Elasticsearch. Every piece of the pipeline is derived from the values in this file so
+# that end-users only need to adjust configuration rather than writing Logstash configuration
+# snippets by hand.
+
+replicaCount: 1
+
+image:
+  repository: docker.elastic.co/logstash/logstash
+  tag: "8.11.0"
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+  automount: true
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+securityContext: {}
+
+service:
+  enabled: true
+  type: ClusterIP
+  port: 9600
+  annotations: {}
+  labels: {}
+
+resources: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+extraEnv: []
+extraEnvFrom: []
+extraVolumeMounts: []
+extraVolumes: []
+extraInitContainers: []
+extraContainers: []
+
+# Raw Logstash configuration files. The defaults expose the HTTP monitoring endpoint and load the
+# generated pipeline. Use tpl syntax in overrides if you need to interpolate Helm values.
+logstashConfig:
+  logstash.yml: |
+    http.host: "0.0.0.0"
+    monitoring.enabled: false
+  pipelines.yml: |
+    - pipeline.id: main
+      path.config: /usr/share/logstash/pipeline/logstash.conf
+
+# Pipeline configuration options.
+pipeline:
+  # Field that will host the aggregated payload once the event is ready for mapping. Bracket
+  # notation is used throughout the chart; the helper templates will automatically add brackets if
+  # they are omitted (e.g. "payload" becomes "[payload]").
+  payloadField: "payload"
+  keepPayloadField: false
+
+  # Optional list of fields to remove after mapping (in addition to the payload field when
+  # keepPayloadField is false). Use Logstash bracket notation for nested fields.
+  removeFields: []
+
+  # When true, events without a payload (after enrichment attempts) are tagged with
+  # `missing_payload`. If `dropOnMissingPayload` is also true those tagged events are dropped.
+  tagMissingPayload: true
+  dropOnMissingPayload: false
+
+  # Optional static fields that should be added to every event prior to the output stage.
+  staticFields: {}
+
+  kafka:
+    bootstrapServers:
+      - kafka:9092
+    topics:
+      - events
+    groupId: logstash-indexer
+    clientId: ""
+    autoOffsetReset: latest
+    securityProtocol: PLAINTEXT
+    decorateEvents: false
+    consumerThreads: 1
+
+    # Additional arbitrary kafka input plugin options expressed as key/value pairs. Values can be
+    # strings, numbers, or booleans.
+    additionalOptions: {}
+
+    codec: json
+
+    sasl:
+      enabled: false
+      mechanism: PLAIN
+      username: ""
+      password:
+        value: ""
+        existingSecret: ""
+        key: ""
+        envVar: KAFKA_SASL_PASSWORD
+
+    ssl:
+      enabled: false
+      truststore: ""
+      truststorePassword:
+        value: ""
+        existingSecret: ""
+        key: ""
+        envVar: KAFKA_TRUSTSTORE_PASSWORD
+      keystore: ""
+      keystorePassword:
+        value: ""
+        existingSecret: ""
+        key: ""
+        envVar: KAFKA_KEYSTORE_PASSWORD
+      verify: true
+
+  # Field used to route events to the correct enrichment source. When empty the chart only relies on
+  # payload detection logic.
+  sourceTypeField: "source.type"
+
+  inline:
+    enabled: true
+    # Values of the sourceTypeField that identify inline payload events.
+    matchSourceTypes:
+      - inline
+    # Field containing the inline payload. If the field already matches pipeline.payloadField the
+    # data is simply parsed/copied in place. When empty the chart will only use fallback logic.
+    payloadField: "payload"
+    # Whether the payload field contains a JSON string instead of an object.
+    payloadIsJsonString: false
+    # Copy selected root fields into the payload hash when the payload field is missing. When left
+    # empty the chart copies the keys defined in `fieldMappings`.
+    fallbackToRootFields: false
+    rootFieldWhitelist: []
+    # Remove the original inline payload field after it has been merged into the canonical payload.
+    removeSourceAfterExtract: false
+
+  dataSources:
+    rest:
+      enabled: false
+      matchSourceTypes:
+        - rest
+      # Field whose value is used when building the request (for example the record identifier).
+      referenceField: "source.id"
+      fetchCondition: missingPayload # allowed values: missingPayload, always
+      request:
+        urlTemplate: https://api.example.tld/resources/%{[source][id]}
+        method: GET
+        headers: {}
+        params: {}
+        body: ""
+        timeoutSeconds: 60
+        proxy: ""
+      response:
+        format: json # json or text
+        jsonPointer: ""
+        targetField: "" # defaults to pipeline.payloadField when empty
+        statusField: "" # optional field to expose the HTTP status code
+      mergeStrategy: replace # replace or merge
+      allowFailure: false
+
+    mongo:
+      enabled: false
+      matchSourceTypes:
+        - mongo
+      referenceField: "source.id"
+      fetchCondition: missingPayload
+      uri: mongodb://user:password@mongo:27017/database
+      database: sample
+      collection: records
+      queryTemplate: '{ "_id": { "$oid": "%{[source][id]}" } }'
+      projection: ""
+      resultSelector: "" # optional JSON pointer into the query result
+      targetField: "" # defaults to pipeline.payloadField when empty
+      mergeStrategy: replace
+      allowFailure: false
+
+    s3:
+      enabled: false
+      matchSourceTypes:
+        - s3
+      fetchCondition: missingPayload
+      bucket: example-bucket
+      keyTemplate: "%{[source][s3_key]}"
+      versionIdField: "" # optional field containing an object version identifier
+      region: us-east-1
+      targetField: "" # defaults to pipeline.payloadField when empty
+      mergeStrategy: replace
+      contentFormat: json # json or text
+      jsonPointer: ""
+      clientOptions: {}
+      assumeRoleArn: ""
+      allowFailure: false
+
+  # Field mappings from the source payload to the final indexed document. Keys are the source field
+  # names and values are the target field names. The chart will automatically pull the source values
+  # out of the payload and place them at the root event level with the target names so that the
+  # Logstash outputs index the correct fields. Advanced options are available by using an object as
+  # the value, for example:
+  #   fieldMappings:
+  #     title:
+  #       target: title_s
+  #       sourcePath: payload.title
+  #       keepSource: false
+  fieldMappings: {}
+
+  # Optional additional mutate remove instructions applied after the field mappings are processed.
+  removeMappedSourceFields: true
+
+  # Optional filters that should run after all built-in enrichment logic but before the output
+  # section. Each entry should be a Logstash filter snippet (without the surrounding `filter { }`).
+  # Use this sparingly – the intent is to cover corner cases not addressed by the built-in switches.
+  additionalFilters: []
+
+output:
+  type: elasticsearch # allowed values: elasticsearch, solr
+
+  elasticsearch:
+    hosts:
+      - http://elasticsearch:9200
+    index: logstash-%{+YYYY.MM.dd}
+    documentIdField: "" # optional source field containing the document id
+    dataStream: {} # optional map of datastream options (e.g. { enabled: true, type: logs, dataset: custom })
+    manageTemplate: true
+    action: index
+    user: ""
+    password:
+      value: ""
+      existingSecret: ""
+      key: ""
+      envVar: ELASTICSEARCH_PASSWORD
+    apiKey:
+      value: ""
+      existingSecret: ""
+      key: ""
+      envVar: ELASTICSEARCH_API_KEY
+    ssl:
+      enabled: false
+      cacertSecret: ""
+      cacertKey: ""
+      certificateAuthority: ""
+      verify: true
+    additionalOptions: {}
+
+  solr:
+    url: http://solr:8983/solr/gettingstarted
+    collection: ""
+    commitWithin: ""
+    softCommit: false
+    skipCommit: false
+    user: ""
+    password:
+      value: ""
+      existingSecret: ""
+      key: ""
+      envVar: SOLR_PASSWORD
+    additionalOptions: {}
+
+  # Additional raw Logstash output snippets (without the surrounding `output { }`).
+  extraOutputs: []


### PR DESCRIPTION
## Summary
- add a dedicated Helm chart for deploying Logstash with Kafka input and Solr/Elasticsearch outputs
- template the enrichment pipeline to support inline payloads plus REST, MongoDB, and S3 lookups with flexible field mappings
- document chart configuration and options for installing required Logstash plugins

## Testing
- `helm lint charts/logstash-indexer` *(fails: helm not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cba8bdc4e0832caa7a7643d620d314