### PR TITLE
Refine Logstash enrichment pipeline scripts

### DIFF
--- a/charts/logstash-indexer/Chart.yaml
+++ b/charts/logstash-indexer/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: logstash-indexer
+description: Helm chart for running Logstash to index Kafka events into Solr or Elasticsearch with optional data enrichment
+version: 0.1.0
+appVersion: "8.11.0"
+type: application
+keywords:
+  - logstash
+  - kafka
+  - solr
+  - elasticsearch
+  - indexing

--- a/charts/logstash-indexer/README.md
+++ b/charts/logstash-indexer/README.md
@@ -1,0 +1,97 @@
+# Logstash Indexer Helm Chart
+
+This chart deploys a Logstash instance that consumes events from Kafka, enriches them with data
+fetched from a variety of sources, and indexes the resulting documents into either Solr or
+Elasticsearch. Every part of the Logstash pipeline is rendered from `values.yaml`, so operators can
+configure behaviour declaratively without touching raw pipeline syntax.
+
+## Features
+
+* Kafka input with SASL/SSL support and pluggable codec/options.
+* Inline payload handling for events that already contain the full document.
+* Hybrid enrichment via REST APIs, MongoDB lookups, or S3 object retrieval.
+* Flexible field mapping that transforms payload fields to the exact schema expected by the target
+  index.
+* Selectable Solr (`solr_http`) or Elasticsearch output plugins with optional authentication.
+* Rich Pod customisation, including extra containers, volumes, init containers, environment
+  variables, and resource limits.
+
+## Data enrichment modes
+
+Configure the following sections under `pipeline` to control where Logstash should obtain the full
+payload for each event:
+
+* `pipeline.inline` – For events that already contain the full payload. The chart can optionally
+  parse JSON strings, move nested payloads into the canonical payload field, and even duplicate root
+  fields into the payload when only a subset of messages include inline data.
+* `pipeline.dataSources.rest` – Issues HTTP requests to retrieve additional document fields. The
+  request URL, headers, body, and response parsing (including JSON pointer extraction) are fully
+  configurable from values. The chart wires the standard `http`, `json`, and `mutate` filters
+  together so that REST enrichment remains declarative without any custom Ruby code.
+* `pipeline.dataSources.mongo` – Uses the
+  [`logstash-filter-mongodb`](https://github.com/logstash-plugins/logstash-filter-mongodb) plugin to
+  load documents from MongoDB. Customize the query, projection, and result selection pointer.
+* `pipeline.dataSources.s3` – Downloads objects from S3 using the AWS SDK. Supports optional
+  role-assumption, JSON parsing, and pointer-based extraction.
+
+Each data source supports `matchSourceTypes` (values read from `pipeline.sourceTypeField`) so that
+individual events can declare how they should be enriched. Hybrid workflows are supported by
+allowing events to fall back to inline payloads whenever they exist.
+
+> **Note:** Fetching from MongoDB and Solr requires the corresponding Logstash plugins
+> (`logstash-filter-mongodb` and `logstash-output-solr_http`). S3 enrichment depends on the
+> `aws-sdk-s3` (and optionally `aws-sdk-sts`) Ruby gems. Install any required plugins by supplying
+> `extraInitContainers` that run `logstash-plugin install ...` or by extending the Logstash image.
+
+## Ruby helper scripts
+
+Helper Ruby scripts live under `files/scripts` inside the chart and are mounted into the Logstash
+pod at runtime. They encapsulate the inline payload handling, static field defaults, MongoDB result
+merging, and S3 retrieval logic used by the `ruby` filters. Configuration still flows entirely from
+`values.yaml` through `script_params`, keeping the scripts reusable while keeping event behavior
+declarative.
+
+## Field mappings
+
+`pipeline.fieldMappings` describes how to transform payload fields into the final document that will
+be sent to Solr or Elasticsearch. The simplest form is a map where keys are the source field names
+from the payload and values are the destination field names:
+
+```yaml
+pipeline:
+  fieldMappings:
+    title: title_s
+    body: body_txt
+```
+
+When more control is needed, assign an object with `target`, optional `sourcePath` (to read from a
+nested payload path), and `keepSource` to retain the original field after mapping.
+
+```yaml
+pipeline:
+  fieldMappings:
+    summary:
+      target: summary_t
+      sourcePath: payload.metadata.summary
+      keepSource: true
+```
+
+## Outputs
+
+Select the target indexer via `output.type` (`elasticsearch` or `solr`). Each block exposes the most
+commonly used settings, including credentials that are sourced from Kubernetes Secrets via helper
+environment variables. Additional raw Logstash outputs can be appended by populating
+`output.extraOutputs`.
+
+## Installing the chart
+
+Add the chart to your manifests (for example within a Git repository) and customise `values.yaml` to
+match your Kafka, enrichment, and indexing requirements. Once ready, render or install the chart
+with Helm:
+
+```bash
+helm install logstash-indexer ./charts/logstash-indexer -f my-values.yaml
+```
+
+Run `helm template` to inspect the generated Kubernetes manifests and Logstash pipeline before
+applying them to a cluster.

--- a/charts/logstash-indexer/files/scripts/inline_payload.rb
+++ b/charts/logstash-indexer/files/scripts/inline_payload.rb
@@ -1,0 +1,76 @@
+require "logstash/json"
+
+module LogstashScripts
+  class InlinePayload
+    def initialize(params)
+      @payload_field = params["payload_field"] || ""
+      @target_field = params["target_field"] || ""
+      @payload_is_json = !!params["payload_is_json"]
+      @fallback_enabled = !!params["fallback_enabled"]
+      sources = Array(params["fallback_sources"])
+      @fallback_sources = sources.map do |entry|
+        {
+          "name" => entry["name"],
+          "path" => entry["path"]
+        }
+      end
+    end
+
+    def apply(event)
+      data = read_payload(event)
+      return if data.nil?
+
+      if data.is_a?(Hash)
+        event.set(@target_field, data)
+      else
+        event.set(@target_field, data)
+      end
+    end
+
+    private
+
+    def read_payload(event)
+      value = nil
+      value = event.get(@payload_field) unless @payload_field.empty?
+      value = parse_json(event, value) if @payload_is_json
+      return value unless value.nil?
+      return nil unless @fallback_enabled
+
+      collected = collect_from_root(event)
+      collected
+    end
+
+    def parse_json(event, value)
+      return value unless value.is_a?(String)
+
+      LogStash::Json.load(value)
+    rescue StandardError
+      event.tag("inline_payload_parse_failure")
+      nil
+    end
+
+    def collect_from_root(event)
+      data = {}
+      @fallback_sources.each do |source|
+        name = source["name"]
+        path = source["path"]
+        next if path.nil? || path.empty?
+
+        value = event.get(path)
+        next if value.nil?
+
+        data[name] = value
+      end
+      data.empty? ? nil : data
+    end
+  end
+end
+
+def register(params)
+  @handler = LogstashScripts::InlinePayload.new(params)
+end
+
+def filter(event)
+  @handler.apply(event)
+  [event]
+end

--- a/charts/logstash-indexer/files/scripts/mongo_merge.rb
+++ b/charts/logstash-indexer/files/scripts/mongo_merge.rb
@@ -1,0 +1,80 @@
+module LogstashScripts
+  class MongoMerge
+    def initialize(params)
+      @result_field = params["result_field"] || ""
+      @target_field = params["target_field"] || ""
+      @merge = !!params["merge"]
+      @pointer = parse_pointer(params["pointer"] || "")
+    end
+
+    def apply(event)
+      success = false
+      data = event.get(@result_field)
+      data = data.first if data.is_a?(Array)
+      data = navigate(event, data)
+
+      if data.is_a?(Hash)
+        if @merge
+          existing = event.get(@target_field)
+          if existing.is_a?(Hash)
+            event.set(@target_field, existing.merge(data))
+          else
+            event.set(@target_field, data)
+          end
+        else
+          event.set(@target_field, data)
+        end
+        success = true
+      elsif !data.nil?
+        event.set(@target_field, data)
+        success = true
+      end
+
+      event.set("[@metadata][mongo_lookup][success]", success)
+    end
+
+    private
+
+    def parse_pointer(pointer)
+      stripped = pointer.to_s.sub(%r{^/+}, "")
+      return [] if stripped.empty?
+
+      stripped.split("/").map { |segment| decode_pointer_segment(segment) }
+    end
+
+    def decode_pointer_segment(segment)
+      segment.gsub("~1", "/").gsub("~0", "~")
+    end
+
+    def navigate(event, data)
+      return data if @pointer.empty? || data.nil?
+
+      current = data
+      @pointer.each do |segment|
+        case current
+        when Hash
+          current = current[segment]
+        when Array
+          index = segment =~ /^\d+$/ ? segment.to_i : nil
+          current = index ? current[index] : nil
+        else
+          current = nil
+        end
+        break if current.nil?
+      end
+      current
+    rescue StandardError
+      event.tag("mongo_result_parse_failure")
+      nil
+    end
+  end
+end
+
+def register(params)
+  @handler = LogstashScripts::MongoMerge.new(params)
+end
+
+def filter(event)
+  @handler.apply(event)
+  [event]
+end

--- a/charts/logstash-indexer/files/scripts/s3_fetch.rb
+++ b/charts/logstash-indexer/files/scripts/s3_fetch.rb
@@ -1,0 +1,140 @@
+require "aws-sdk-s3"
+require "logstash/json"
+
+module LogstashScripts
+  class S3Fetch
+    def initialize(params)
+      @bucket_template = params["bucket"] || ""
+      @key_template = params["key_template"] || ""
+      @version_field = params["version_field"] || ""
+      @target_field = params["target_field"] || ""
+      @merge = !!params["merge"]
+      @content_format = (params["content_format"] || "json").to_s.downcase
+      @json_pointer = parse_pointer(params["json_pointer"] || "")
+      @client_options = symbolize_keys(params["client_options"] || {})
+      @region = params["region"] || ""
+      @assume_role_arn = params["assume_role_arn"] || ""
+    end
+
+    def apply(event)
+      success = false
+      begin
+        bucket = event.sprintf(@bucket_template)
+        key = event.sprintf(@key_template)
+        version_id = version_identifier(event)
+
+        response = build_client.get_object(request_params(bucket, key, version_id))
+        body = response.body.read
+        data = parse_body(event, body)
+        data = navigate(event, data)
+        success = assign_result(event, data)
+      rescue StandardError
+        event.tag("s3_lookup_error")
+      end
+
+      event.set("[@metadata][s3_lookup][success]", success)
+    end
+
+    private
+
+    def version_identifier(event)
+      return nil if @version_field.empty?
+
+      value = event.get(@version_field)
+      value.nil? || value.to_s.empty? ? nil : value
+    end
+
+    def build_client
+      options = @client_options.dup
+      options[:region] = @region unless @region.to_s.empty?
+
+      if !@assume_role_arn.to_s.empty?
+        require "aws-sdk-sts"
+        sts = Aws::STS::Client.new(options)
+        credentials = sts.assume_role(role_arn: @assume_role_arn, role_session_name: "logstash-indexer").credentials
+        options[:credentials] = Aws::Credentials.new(credentials.access_key_id, credentials.secret_access_key, credentials.session_token)
+      end
+
+      Aws::S3::Client.new(options)
+    end
+
+    def request_params(bucket, key, version_id)
+      params = { bucket: bucket, key: key }
+      params[:version_id] = version_id if version_id
+      params
+    end
+
+    def parse_body(event, body)
+      return body unless @content_format == "json"
+
+      LogStash::Json.load(body)
+    rescue StandardError
+      event.tag("s3_response_parse_failure")
+      nil
+    end
+
+    def navigate(event, data)
+      return data if @json_pointer.empty? || data.nil?
+
+      current = data
+      @json_pointer.each do |segment|
+        case current
+        when Hash
+          current = current[segment]
+        when Array
+          index = segment =~ /^\d+$/ ? segment.to_i : nil
+          current = index ? current[index] : nil
+        else
+          current = nil
+        end
+        break if current.nil?
+      end
+      current
+    rescue StandardError
+      event.tag("s3_pointer_failure")
+      nil
+    end
+
+    def assign_result(event, data)
+      return false if data.nil?
+
+      if data.is_a?(Hash)
+        if @merge
+          existing = event.get(@target_field)
+          if existing.is_a?(Hash)
+            event.set(@target_field, existing.merge(data))
+          else
+            event.set(@target_field, data)
+          end
+        else
+          event.set(@target_field, data)
+        end
+      else
+        event.set(@target_field, data)
+      end
+      true
+    end
+
+    def symbolize_keys(source)
+      source.each_with_object({}) do |(key, value), memo|
+        memo[key.to_sym] = value
+      end
+    end
+
+    def parse_pointer(pointer)
+      stripped = pointer.to_s.sub(%r{^/+}, "")
+      return [] if stripped.empty?
+
+      stripped.split("/").map { |segment| segment.gsub("~1", "/").gsub("~0", "~") }
+    end
+  end
+end
+
+def register(params)
+  @handler = LogstashScripts::S3Fetch.new(params)
+end
+
+def filter(event)
+  @handler.apply(event)
+  [event]
+end

--- a/charts/logstash-indexer/files/scripts/static_fields.rb
+++ b/charts/logstash-indexer/files/scripts/static_fields.rb
@@ -1,0 +1,26 @@
+module LogstashScripts
+  class StaticFields
+    def initialize(params)
+      @fields = {}
+      (params["fields"] || {}).each do |key, value|
+        @fields[key] = value
+      end
+    end
+
+    def apply(event)
+      @fields.each do |field, value|
+        next unless event.get(field).nil?
+        event.set(field, value)
+      end
+    end
+  end
+end
+
+def register(params)
+  @handler = LogstashScripts::StaticFields.new(params)
+end
+
+def filter(event)
+  @handler.apply(event)
+  [event]
+end

--- a/charts/logstash-indexer/templates/_helpers.tpl
+++ b/charts/logstash-indexer/templates/_helpers.tpl
@@ -1,0 +1,162 @@
+{{- define "logstash-indexer.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "logstash-indexer.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "logstash-indexer.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version -}}
+{{- end -}}
+
+{{- define "logstash-indexer.labels" -}}
+helm.sh/chart: {{ include "logstash-indexer.chart" . }}
+{{ include "logstash-indexer.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{- end -}}
+
+{{- define "logstash-indexer.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "logstash-indexer.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "logstash-indexer.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{ default (include "logstash-indexer.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+{{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{- define "logstash-indexer.toFieldRef" -}}
+{{- $field := . | default "" -}}
+{{- if eq $field "" -}}
+{{- "" -}}
+{{- else if hasPrefix $field "[" -}}
+{{- $field -}}
+{{- else -}}
+{{- $normalized := regexReplaceAll "\\." $field "][" -}}
+[{{ $normalized }}]
+{{- end -}}
+{{- end -}}
+
+{{- define "logstash-indexer.appendField" -}}
+{{- $base := include "logstash-indexer.toFieldRef" .base -}}
+{{- $fieldRef := include "logstash-indexer.toFieldRef" .field -}}
+{{- if eq $base "" -}}
+{{- $fieldRef -}}
+{{- else if eq $fieldRef "" -}}
+{{- $base -}}
+{{- else -}}
+{{- $trimmed := trimSuffix "]" (trimPrefix "[" $fieldRef) -}}
+{{ printf "%s[%s]" $base $trimmed }}
+{{- end -}}
+{{- end -}}
+
+{{- define "logstash-indexer.jsonPointerField" -}}
+{{- $base := .base | default "" -}}
+{{- $pointer := .pointer | default "" -}}
+{{- $field := $base -}}
+{{- $trimmed := trimPrefix "/" $pointer -}}
+{{- if ne $trimmed "" -}}
+{{- $segments := splitList "/" $trimmed -}}
+{{- range $segment := $segments -}}
+{{- $decoded := replace (replace $segment "~1" "/") "~0" "~" -}}
+{{- if eq $field "" -}}
+{{- $field = include "logstash-indexer.toFieldRef" $decoded -}}
+{{- else -}}
+{{- $field = include "logstash-indexer.appendField" (dict "base" $field "field" $decoded) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- if eq $field "" -}}
+{{- $field = $base -}}
+{{- end -}}
+{{- $field -}}
+{{- end -}}
+
+{{- define "logstash-indexer.renderValue" -}}
+{{- $v := . -}}
+{{- if kindIs "string" $v -}}
+"{{ $v }}"
+{{- else if kindIs "bool" $v -}}
+{{- if $v }}true{{ else }}false{{ end -}}
+{{- else if or (kindIs "int64" $v) (kindIs "float64" $v) (kindIs "float32" $v) (kindIs "int" $v) -}}
+{{ $v }}
+{{- else if kindIs "slice" $v -}}
+[{{- $first := true -}}{{- range $item := $v -}}{{- if $first -}}{{- $first = false -}}{{ else }}, {{ end -}}{{ include "logstash-indexer.renderValue" $item }}{{- end -}}]
+{{- else if kindIs "map" $v -}}
+{{- include "logstash-indexer.renderHash" $v -}}
+{{- else -}}
+"{{ $v }}"
+{{- end -}}
+{{- end -}}
+
+{{- define "logstash-indexer.renderHash" -}}
+{{- $map := . -}}
+{{- if $map }}
+{ {{- $first := true -}}{{- range $k, $val := $map -}}{{- if $first -}}{{- $first = false -}}{{ else }}, {{ end -}}"{{ $k }}" => {{ include "logstash-indexer.renderValue" $val }}{{- end -}} }
+{{- else -}}
+{ }
+{{- end -}}
+{{- end -}}
+
+{{- define "logstash-indexer.renderList" -}}
+[{{- $first := true -}}{{- range $item := . -}}{{- if $first -}}{{- $first = false -}}{{ else }}, {{ end -}}{{ include "logstash-indexer.renderValue" $item }}{{- end -}}]
+{{- end -}}
+
+{{- define "logstash-indexer.fieldPresenceCondition" -}}
+{{- $fields := . | default (list) -}}
+{{- $first := true -}}
+{{- range $field := $fields -}}
+{{- $ref := include "logstash-indexer.toFieldRef" $field -}}
+{{- if $ref }}
+{{- if $first -}}{{- $first = false -}}{{ else }} and {{ end -}}{{ $ref }}
+{{- end -}}
+{{- end -}}
+{{- if $first }}false{{- end -}}
+{{- end -}}
+
+{{- define "logstash-indexer.sourceTypeCondition" -}}
+{{- $field := include "logstash-indexer.toFieldRef" .field -}}
+{{- $values := .values | default (list) -}}
+{{- if and $field (gt (len $values) 0) -}}
+{{- $first := true -}}
+{{- range $val := $values -}}
+{{- if ne (printf "%v" $val) "" -}}
+{{- if $first -}}{{- $first = false -}}{{ else }} or {{ end -}}{{ printf "%s == \"%s\"" $field $val }}
+{{- end -}}
+{{- end -}}
+{{- if $first }}false{{- end -}}
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{- define "logstash-indexer.renderSecretEnv" -}}
+{{- $cfg := . -}}
+{{- if and $cfg.envVar (or $cfg.value (and $cfg.existingSecret $cfg.key)) }}
+- name: {{ $cfg.envVar }}
+  {{- if $cfg.value }}
+  value: {{ $cfg.value | quote }}
+  {{- else }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $cfg.existingSecret }}
+      key: {{ $cfg.key }}
+  {{- end }}
+{{- end -}}
+{{- end -}}

--- a/charts/logstash-indexer/templates/configmap-config.yaml
+++ b/charts/logstash-indexer/templates/configmap-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "logstash-indexer.fullname" . }}-config
+  labels:
+    {{- include "logstash-indexer.labels" . | nindent 4 }}
+data:
+{{- range $name, $content := .Values.logstashConfig }}
+  {{ $name }}: |
+{{ tpl $content $ | indent 4 }}
+{{- end }}

--- a/charts/logstash-indexer/templates/configmap-pipeline.yaml
+++ b/charts/logstash-indexer/templates/configmap-pipeline.yaml
@@ -1,0 +1,408 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "logstash-indexer.fullname" . }}-pipeline
+  labels:
+    {{- include "logstash-indexer.labels" . | nindent 4 }}
+data:
+  logstash.conf: |
+    {{- $payloadFieldRaw := include "logstash-indexer.toFieldRef" .Values.pipeline.payloadField -}}
+    {{- $payloadField := $payloadFieldRaw -}}
+    {{- if eq $payloadField "" }}
+    {{- $payloadField = "[payload]" -}}
+    {{- end }}
+    {{- $mappingRaw := default (dict) .Values.pipeline.fieldMappings -}}
+    {{- $mappingEntries := list -}}
+    {{- range $source, $cfg := $mappingRaw }}
+    {{- $entry := dict "sourceName" $source "targetName" "" "sourcePath" "" "targetPath" "" "keepSource" false -}}
+    {{- if kindIs "string" $cfg }}
+    {{- $_ := set $entry "targetName" $cfg -}}
+    {{- else if kindIs "map" $cfg }}
+    {{- if hasKey $cfg "target" }}{{- $_ := set $entry "targetName" (index $cfg "target") -}}{{- end -}}
+    {{- if hasKey $cfg "source" }}{{- $_ := set $entry "sourceName" (index $cfg "source") -}}{{- end -}}
+    {{- if hasKey $cfg "sourcePath" }}{{- $_ := set $entry "sourcePath" (index $cfg "sourcePath") -}}{{- end -}}
+    {{- if hasKey $cfg "keepSource" }}{{- $_ := set $entry "keepSource" (index $cfg "keepSource") -}}{{- end -}}
+    {{- end -}}
+    {{- if eq (index $entry "sourcePath") "" }}
+    {{- $_ := set $entry "sourcePath" (include "logstash-indexer.appendField" (dict "base" $payloadField "field" (index $entry "sourceName"))) -}}
+    {{- else -}}
+    {{- $_ := set $entry "sourcePath" (include "logstash-indexer.toFieldRef" (index $entry "sourcePath")) -}}
+    {{- end -}}
+    {{- if eq (index $entry "targetName") "" }}
+    {{- $_ := set $entry "targetName" (index $entry "sourceName") -}}
+    {{- end -}}
+    {{- $_ := set $entry "targetPath" (include "logstash-indexer.toFieldRef" (index $entry "targetName")) -}}
+    {{- $mappingEntries = append $mappingEntries $entry -}}
+    {{- end -}}
+    {{- $inlineWhitelist := .Values.pipeline.inline.rootFieldWhitelist | default (list) -}}
+    {{- $inlineRootFields := ternary $inlineWhitelist (keys $mappingRaw) (gt (len $inlineWhitelist) 0) -}}
+    {{- $inlineFallbackSources := list -}}
+    {{- range $field := $inlineRootFields }}
+    {{- $inlineFallbackSources = append $inlineFallbackSources (dict "name" $field "path" (include "logstash-indexer.toFieldRef" $field)) -}}
+    {{- end -}}
+    {{- $inlinePayloadField := include "logstash-indexer.toFieldRef" .Values.pipeline.inline.payloadField -}}
+    {{- $inlineSourceCondition := include "logstash-indexer.sourceTypeCondition" (dict "field" .Values.pipeline.sourceTypeField "values" .Values.pipeline.inline.matchSourceTypes) -}}
+    {{- $inlineCondition := "" -}}
+    {{- if ne $inlineSourceCondition "false" }}
+    {{- $inlineCondition = printf "(%s)" $inlineSourceCondition -}}
+    {{- end -}}
+    {{- if ne $inlinePayloadField "" }}
+    {{- if ne $inlineCondition "" -}}
+    {{- $inlineCondition = printf "%s or %s" $inlineCondition $inlinePayloadField -}}
+    {{- else -}}
+    {{- $inlineCondition = $inlinePayloadField -}}
+    {{- end -}}
+    {{- end -}}
+    {{- if eq $inlineCondition "" }}
+    {{- $inlineCondition = "false" -}}
+    {{- end -}}
+    {{- $payloadExistsCondition := $payloadField -}}
+    {{- $payloadMissingCondition := printf "!%s" $payloadField -}}
+    input {
+      kafka {
+        bootstrap_servers => "{{ join "," .Values.pipeline.kafka.bootstrapServers }}"
+        topics => {{ include "logstash-indexer.renderList" .Values.pipeline.kafka.topics }}
+        group_id => "{{ .Values.pipeline.kafka.groupId }}"
+        {{- if .Values.pipeline.kafka.clientId }}
+        client_id => "{{ .Values.pipeline.kafka.clientId }}"
+        {{- end }}
+        {{- if .Values.pipeline.kafka.autoOffsetReset }}
+        auto_offset_reset => "{{ .Values.pipeline.kafka.autoOffsetReset }}"
+        {{- end }}
+        {{- if .Values.pipeline.kafka.securityProtocol }}
+        security_protocol => "{{ .Values.pipeline.kafka.securityProtocol }}"
+        {{- end }}
+        {{- if .Values.pipeline.kafka.decorateEvents }}
+        decorate_events => true
+        {{- end }}
+        {{- if gt (int .Values.pipeline.kafka.consumerThreads) 1 }}
+        consumer_threads => {{ .Values.pipeline.kafka.consumerThreads }}
+        {{- end }}
+        {{- if .Values.pipeline.kafka.codec }}
+        codec => {{ .Values.pipeline.kafka.codec }}
+        {{- end }}
+        {{- if .Values.pipeline.kafka.sasl.enabled }}
+        sasl_mechanism => "{{ .Values.pipeline.kafka.sasl.mechanism }}"
+        sasl_plain_username => "{{ .Values.pipeline.kafka.sasl.username }}"
+        sasl_plain_password => "${{{ .Values.pipeline.kafka.sasl.password.envVar }}}"
+        {{- end }}
+        {{- if .Values.pipeline.kafka.ssl.enabled }}
+        ssl => true
+        {{- if .Values.pipeline.kafka.ssl.truststore }}
+        ssl_truststore_location => "{{ .Values.pipeline.kafka.ssl.truststore }}"
+        {{- end }}
+        {{- if .Values.pipeline.kafka.ssl.truststorePassword.envVar }}
+        ssl_truststore_password => "${{{ .Values.pipeline.kafka.ssl.truststorePassword.envVar }}}"
+        {{- end }}
+        {{- if .Values.pipeline.kafka.ssl.keystore }}
+        ssl_keystore_location => "{{ .Values.pipeline.kafka.ssl.keystore }}"
+        {{- end }}
+        {{- if .Values.pipeline.kafka.ssl.keystorePassword.envVar }}
+        ssl_keystore_password => "${{{ .Values.pipeline.kafka.ssl.keystorePassword.envVar }}}"
+        {{- end }}
+        {{- if not .Values.pipeline.kafka.ssl.verify }}
+        ssl_endpoint_identification_algorithm => ""
+        {{- end }}
+        {{- end }}
+        {{- range $key, $val := .Values.pipeline.kafka.additionalOptions }}
+        {{ $key }} => {{ include "logstash-indexer.renderValue" $val }}
+        {{- end }}
+      }
+    }
+
+    filter {
+      {{- if .Values.pipeline.staticFields }}
+      ruby {
+        id => "static-fields"
+        path => "/usr/share/logstash/pipeline/scripts/static_fields.rb"
+        script_params => {
+          "fields" => {{ include "logstash-indexer.renderHash" .Values.pipeline.staticFields }}
+        }
+      }
+      {{- end }}
+
+      {{- if and .Values.pipeline.inline.enabled (ne $inlineCondition "false") }}
+      if {{ $inlineCondition }} {
+        ruby {
+          id => "inline-payload"
+          path => "/usr/share/logstash/pipeline/scripts/inline_payload.rb"
+          script_params => {
+            "payload_field" => {{ include "logstash-indexer.toFieldRef" .Values.pipeline.inline.payloadField | quote }}
+            "target_field" => {{ $payloadField | quote }}
+            "payload_is_json" => {{ if .Values.pipeline.inline.payloadIsJsonString }}true{{ else }}false{{ end }}
+            "fallback_enabled" => {{ if .Values.pipeline.inline.fallbackToRootFields }}true{{ else }}false{{ end }}
+            "fallback_sources" => {{ include "logstash-indexer.renderList" $inlineFallbackSources }}
+          }
+        }
+        {{- if and .Values.pipeline.inline.removeSourceAfterExtract (ne $inlinePayloadField "") }}
+        mutate {
+          remove_field => [{{ include "logstash-indexer.renderValue" (include "logstash-indexer.toFieldRef" .Values.pipeline.inline.payloadField) }}]
+        }
+        {{- end }}
+      }
+      {{- end }}
+
+      {{- $rest := .Values.pipeline.dataSources.rest -}}
+      {{- if $rest.enabled }}
+      if ({{ include "logstash-indexer.sourceTypeCondition" (dict "field" .Values.pipeline.sourceTypeField "values" $rest.matchSourceTypes) }}{{- if eq $rest.fetchCondition "missingPayload" }} and {{ $payloadMissingCondition }}{{- end }}) {
+        http {
+          id => "rest-fetch"
+          url => "{{ $rest.request.urlTemplate }}"
+          verb => "{{ default "get" (lower $rest.request.method) }}"
+          target_body => "[@metadata][rest_lookup][body]"
+          target_headers => "[@metadata][rest_lookup][headers]"
+          target_status_code => "[@metadata][rest_lookup][status]"
+          {{- if $rest.request.headers }}
+          headers => {{ include "logstash-indexer.renderHash" $rest.request.headers }}
+          {{- end }}
+          {{- if $rest.request.params }}
+          params => {{ include "logstash-indexer.renderHash" $rest.request.params }}
+          {{- end }}
+          {{- if $rest.request.body }}
+          body => "{{ $rest.request.body }}"
+          {{- end }}
+          {{- if gt (int $rest.request.timeoutSeconds) 0 }}
+          connect_timeout => {{ $rest.request.timeoutSeconds }}
+          {{- end }}
+          {{- if $rest.request.proxy }}
+          proxy => "{{ $rest.request.proxy }}"
+          {{- end }}
+        }
+        mutate {
+          remove_field => ["[@metadata][rest_lookup][result]", "[@metadata][rest_lookup][parsed]"]
+        }
+        {{- $restFormat := lower (default "json" $rest.response.format) -}}
+        {{- if eq $restFormat "json" }}
+        json {
+          id => "rest-parse"
+          source => "[@metadata][rest_lookup][body]"
+          target => "[@metadata][rest_lookup][parsed]"
+          remove_field => ["[@metadata][rest_lookup][body]"]
+        }
+        {{- else }}
+        mutate {
+          copy => { "[@metadata][rest_lookup][body]" => "[@metadata][rest_lookup][parsed]" }
+          remove_field => ["[@metadata][rest_lookup][body]"]
+        }
+        {{- end }}
+        {{- $restTargetField := default $payloadField (include "logstash-indexer.toFieldRef" $rest.response.targetField) -}}
+        {{- $restPointerRef := include "logstash-indexer.jsonPointerField" (dict "base" "[@metadata][rest_lookup][parsed]" "pointer" $rest.response.jsonPointer) -}}
+        if [@metadata][rest_lookup][parsed] {
+          mutate {
+            copy => { "{{ $restPointerRef }}" => "[@metadata][rest_lookup][result]" }
+          }
+        }
+        if [@metadata][rest_lookup][result] {
+          {{- if eq $rest.mergeStrategy "merge" }}
+          if {{ $restTargetField }} {
+            mutate {
+              merge => { "{{ $restTargetField }}" => "[@metadata][rest_lookup][result]" }
+            }
+          } else {
+            mutate {
+              copy => { "[@metadata][rest_lookup][result]" => "{{ $restTargetField }}" }
+            }
+          }
+          {{- else }}
+          mutate {
+            copy => { "[@metadata][rest_lookup][result]" => "{{ $restTargetField }}" }
+          }
+          {{- end }}
+        }
+        {{- if $rest.response.statusField }}
+        mutate {
+          rename => { "[@metadata][rest_lookup][status]" => {{ include "logstash-indexer.toFieldRef" $rest.response.statusField }} }
+        }
+        {{- end }}
+        if ![@metadata][rest_lookup][result] {
+          mutate { add_tag => ["rest_lookup_failed"] }
+          {{- if not $rest.allowFailure }}
+          drop { }
+          {{- end }}
+        }
+      }
+      {{- end }}
+
+      {{- $mongo := .Values.pipeline.dataSources.mongo -}}
+      {{- if $mongo.enabled }}
+      if ({{ include "logstash-indexer.sourceTypeCondition" (dict "field" .Values.pipeline.sourceTypeField "values" $mongo.matchSourceTypes) }}{{- if eq $mongo.fetchCondition "missingPayload" }} and {{ $payloadMissingCondition }}{{- end }}) {
+        mongodb {
+          id => "mongo-fetch"
+          uri => "{{ $mongo.uri }}"
+          database => "{{ $mongo.database }}"
+          collection => "{{ $mongo.collection }}"
+          filter => {{ $mongo.queryTemplate | quote }}
+          {{- if $mongo.projection }}
+          projection => {{ $mongo.projection | quote }}
+          {{- end }}
+          target => "[@metadata][mongo_lookup][results]"
+        }
+        ruby {
+          id => "mongo-merge"
+          path => "/usr/share/logstash/pipeline/scripts/mongo_merge.rb"
+          script_params => {
+            "result_field" => "[@metadata][mongo_lookup][results]"
+            "target_field" => {{ default $payloadField (include "logstash-indexer.toFieldRef" $mongo.targetField) | quote }}
+            "pointer" => {{ default "" $mongo.resultSelector | quote }}
+            "merge" => {{ if eq $mongo.mergeStrategy "merge" }}true{{ else }}false{{ end }}
+          }
+        }
+        if ![@metadata][mongo_lookup][success] {
+          mutate { add_tag => ["mongo_lookup_failed"] }
+          {{- if not $mongo.allowFailure }}
+          drop { }
+          {{- end }}
+        }
+      }
+      {{- end }}
+
+      {{- $s3 := .Values.pipeline.dataSources.s3 -}}
+      {{- if $s3.enabled }}
+      if ({{ include "logstash-indexer.sourceTypeCondition" (dict "field" .Values.pipeline.sourceTypeField "values" $s3.matchSourceTypes) }}{{- if eq $s3.fetchCondition "missingPayload" }} and {{ $payloadMissingCondition }}{{- end }}) {
+        ruby {
+          id => "s3-fetch"
+          path => "/usr/share/logstash/pipeline/scripts/s3_fetch.rb"
+          script_params => {
+            "bucket" => {{ $s3.bucket | quote }}
+            "key_template" => {{ $s3.keyTemplate | quote }}
+            "version_field" => {{ include "logstash-indexer.toFieldRef" $s3.versionIdField | quote }}
+            "target_field" => {{ default $payloadField (include "logstash-indexer.toFieldRef" $s3.targetField) | quote }}
+            "merge" => {{ if eq $s3.mergeStrategy "merge" }}true{{ else }}false{{ end }}
+            "content_format" => {{ default "json" $s3.contentFormat | lower | quote }}
+            "json_pointer" => {{ default "" $s3.jsonPointer | quote }}
+            "client_options" => {{ include "logstash-indexer.renderHash" $s3.clientOptions }}
+            "region" => {{ $s3.region | quote }}
+            "assume_role_arn" => {{ $s3.assumeRoleArn | quote }}
+          }
+        }
+        if ![@metadata][s3_lookup][success] {
+          mutate { add_tag => ["s3_lookup_failed"] }
+          {{- if not $s3.allowFailure }}
+          drop { }
+          {{- end }}
+        }
+      }
+      {{- end }}
+
+      {{- if gt (len $mappingEntries) 0 }}
+      mutate {
+        rename => {
+{{- range $entry := $mappingEntries }}
+          "{{ index $entry "sourcePath" }}" => "{{ index $entry "targetPath" }}"
+{{- end }}
+        }
+      }
+      {{- end }}
+
+      {{- if and .Values.pipeline.removeMappedSourceFields (gt (len $mappingEntries) 0) }}
+      {{- $mappedSources := list -}}
+      {{- range $entry := $mappingEntries }}
+        {{- $sourceRef := include "logstash-indexer.toFieldRef" (index $entry "sourceName") -}}
+        {{- if and (not (index $entry "keepSource")) (ne $sourceRef (index $entry "targetPath")) }}
+          {{- $mappedSources = append $mappedSources $sourceRef -}}
+        {{- end -}}
+      {{- end }}
+      {{- if gt (len $mappedSources) 0 }}
+      mutate {
+        remove_field => {{ include "logstash-indexer.renderList" $mappedSources }}
+      }
+      {{- end }}
+      {{- end }}
+
+      {{- $removeList := list -}}
+      {{- if and (ne $payloadField "") (not .Values.pipeline.keepPayloadField) }}
+      {{- $removeList = append $removeList $payloadField -}}
+      {{- end }}
+      {{- range $field := .Values.pipeline.removeFields }}
+      {{- $removeList = append $removeList (include "logstash-indexer.toFieldRef" $field) -}}
+      {{- end }}
+      {{- if gt (len $removeList) 0 }}
+      mutate {
+        remove_field => {{ include "logstash-indexer.renderList" $removeList }}
+      }
+      {{- end }}
+
+      {{- if .Values.pipeline.additionalFilters }}
+{{- range $filter := .Values.pipeline.additionalFilters }}
+      {{ $filter }}
+{{- end }}
+      {{- end }}
+
+      {{- if and .Values.pipeline.tagMissingPayload (ne $payloadField "") }}
+      if !({{ $payloadExistsCondition }}) {
+        mutate { add_tag => ["missing_payload"] }
+        {{- if .Values.pipeline.dropOnMissingPayload }}
+        drop { }
+        {{- end }}
+      }
+      {{- end }}
+    }
+
+    output {
+      {{- if eq .Values.output.type "solr" }}
+      solr_http {
+        url => "{{ .Values.output.solr.url }}"
+        {{- if .Values.output.solr.collection }}
+        collection => "{{ .Values.output.solr.collection }}"
+        {{- end }}
+        {{- if .Values.output.solr.commitWithin }}
+        commit_within => {{ .Values.output.solr.commitWithin }}
+        {{- end }}
+        {{- if .Values.output.solr.softCommit }}
+        soft_commit => true
+        {{- end }}
+        {{- if .Values.output.solr.skipCommit }}
+        skip_commit => true
+        {{- end }}
+        {{- if .Values.output.solr.user }}
+        user => "{{ .Values.output.solr.user }}"
+        {{- end }}
+        {{- if .Values.output.solr.password.envVar }}
+        password => "${{{ .Values.output.solr.password.envVar }}}"
+        {{- end }}
+        {{- range $key, $val := .Values.output.solr.additionalOptions }}
+        {{ $key }} => {{ include "logstash-indexer.renderValue" $val }}
+        {{- end }}
+      }
+      {{- else }}
+      elasticsearch {
+        hosts => {{ include "logstash-indexer.renderList" .Values.output.elasticsearch.hosts }}
+        index => "{{ .Values.output.elasticsearch.index }}"
+        {{- $docIdRef := include "logstash-indexer.toFieldRef" .Values.output.elasticsearch.documentIdField -}}
+        {{- if ne $docIdRef "" }}
+        document_id => "{{ printf "%%{%s}" $docIdRef }}"
+        {{- end }}
+        action => "{{ .Values.output.elasticsearch.action }}"
+        {{- if .Values.output.elasticsearch.user }}
+        user => "{{ .Values.output.elasticsearch.user }}"
+        {{- end }}
+        {{- if .Values.output.elasticsearch.password.envVar }}
+        password => "${{{ .Values.output.elasticsearch.password.envVar }}}"
+        {{- end }}
+        {{- if .Values.output.elasticsearch.apiKey.envVar }}
+        api_key => "${{{ .Values.output.elasticsearch.apiKey.envVar }}}"
+        {{- end }}
+        {{- if .Values.output.elasticsearch.manageTemplate | not }}
+        manage_template => false
+        {{- end }}
+        {{- if .Values.output.elasticsearch.dataStream.enabled }}
+        data_stream => {{ include "logstash-indexer.renderHash" .Values.output.elasticsearch.dataStream }}
+        {{- end }}
+        {{- if .Values.output.elasticsearch.ssl.enabled }}
+        ssl => true
+        {{- if .Values.output.elasticsearch.ssl.certificateAuthority }}
+        cacert => "{{ .Values.output.elasticsearch.ssl.certificateAuthority }}"
+        {{- end }}
+        {{- if not .Values.output.elasticsearch.ssl.verify }}
+        ssl_certificate_verification => false
+        {{- end }}
+        {{- end }}
+        {{- range $key, $val := .Values.output.elasticsearch.additionalOptions }}
+        {{ $key }} => {{ include "logstash-indexer.renderValue" $val }}
+        {{- end }}
+      }
+      {{- end }}
+{{- range $extra := .Values.output.extraOutputs }}
+      {{ $extra }}
+{{- end }}
+    }

--- a/charts/logstash-indexer/templates/configmap-ruby.yaml
+++ b/charts/logstash-indexer/templates/configmap-ruby.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "logstash-indexer.fullname" . }}-ruby
+  labels:
+    {{- include "logstash-indexer.labels" . | nindent 4 }}
+data:
+  inline_payload.rb: |
+{{ (.Files.Get "scripts/inline_payload.rb") | indent 4 }}
+  static_fields.rb: |
+{{ (.Files.Get "scripts/static_fields.rb") | indent 4 }}
+  mongo_merge.rb: |
+{{ (.Files.Get "scripts/mongo_merge.rb") | indent 4 }}
+  s3_fetch.rb: |
+{{ (.Files.Get "scripts/s3_fetch.rb") | indent 4 }}

--- a/charts/logstash-indexer/templates/deployment.yaml
+++ b/charts/logstash-indexer/templates/deployment.yaml
@@ -1,0 +1,132 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "logstash-indexer.fullname" . }}
+  labels:
+    {{- include "logstash-indexer.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "logstash-indexer.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "logstash-indexer.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "logstash-indexer.serviceAccountName" . }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- range . }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.extraInitContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: logstash
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- $kafkaSaslEnv := include "logstash-indexer.renderSecretEnv" .Values.pipeline.kafka.sasl.password -}}
+          {{- $kafkaTruststoreEnv := include "logstash-indexer.renderSecretEnv" .Values.pipeline.kafka.ssl.truststorePassword -}}
+          {{- $kafkaKeystoreEnv := include "logstash-indexer.renderSecretEnv" .Values.pipeline.kafka.ssl.keystorePassword -}}
+          {{- $esPasswordEnv := include "logstash-indexer.renderSecretEnv" .Values.output.elasticsearch.password -}}
+          {{- $esApiKeyEnv := include "logstash-indexer.renderSecretEnv" .Values.output.elasticsearch.apiKey -}}
+          {{- $solrPasswordEnv := include "logstash-indexer.renderSecretEnv" .Values.output.solr.password -}}
+          {{- $hasEnv := or (ne $kafkaSaslEnv "") (ne $kafkaTruststoreEnv "") (ne $kafkaKeystoreEnv "") (ne $esPasswordEnv "") (ne $esApiKeyEnv "") (ne $solrPasswordEnv "") (gt (len .Values.extraEnv) 0) -}}
+          {{- if $hasEnv }}
+          env:
+            {{- if ne $kafkaSaslEnv "" }}
+{{ $kafkaSaslEnv | indent 12 }}
+            {{- end }}
+            {{- if ne $kafkaTruststoreEnv "" }}
+{{ $kafkaTruststoreEnv | indent 12 }}
+            {{- end }}
+            {{- if ne $kafkaKeystoreEnv "" }}
+{{ $kafkaKeystoreEnv | indent 12 }}
+            {{- end }}
+            {{- if ne $esPasswordEnv "" }}
+{{ $esPasswordEnv | indent 12 }}
+            {{- end }}
+            {{- if ne $esApiKeyEnv "" }}
+{{ $esApiKeyEnv | indent 12 }}
+            {{- end }}
+            {{- if ne $solrPasswordEnv "" }}
+{{ $solrPasswordEnv | indent 12 }}
+            {{- end }}
+            {{- range .Values.extraEnv }}
+{{ toYaml . | indent 12 }}
+            {{- end }}
+          {{- end }}
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
+{{ toYaml . | indent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /usr/share/logstash/config/logstash.yml
+              subPath: logstash.yml
+            - name: config
+              mountPath: /usr/share/logstash/config/pipelines.yml
+              subPath: pipelines.yml
+            - name: pipeline
+              mountPath: /usr/share/logstash/pipeline/logstash.conf
+              subPath: logstash.conf
+            - name: ruby-scripts
+              mountPath: /usr/share/logstash/pipeline/scripts
+            {{- range .Values.extraVolumeMounts }}
+{{ toYaml . | indent 12 }}
+            {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- with .Values.extraContainers }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "logstash-indexer.fullname" . }}-config
+        - name: pipeline
+          configMap:
+            name: {{ include "logstash-indexer.fullname" . }}-pipeline
+        - name: ruby-scripts
+          configMap:
+            name: {{ include "logstash-indexer.fullname" . }}-ruby
+{{- range .Values.extraVolumes }}
+{{ toYaml . | indent 8 }}
+{{- end }}

--- a/charts/logstash-indexer/templates/service.yaml
+++ b/charts/logstash-indexer/templates/service.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.service.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "logstash-indexer.fullname" . }}
+  labels:
+    {{- include "logstash-indexer.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "logstash-indexer.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/logstash-indexer/templates/serviceaccount.yaml
+++ b/charts/logstash-indexer/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "logstash-indexer.serviceAccountName" . }}
+  labels:
+    {{- include "logstash-indexer.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- if hasKey .Values.serviceAccount "automount" }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}
+{{- end }}

--- a/charts/logstash-indexer/values.yaml
+++ b/charts/logstash-indexer/values.yaml
@@ -1,0 +1,271 @@
+# Default values for the Logstash indexer chart.
+#
+# The chart renders an opinionated Logstash pipeline that consumes Kafka events and optionally
+# enriches them by pulling additional fields from REST APIs, MongoDB, or S3 before indexing into
+# Solr or Elasticsearch. Every piece of the pipeline is derived from the values in this file so
+# that end-users only need to adjust configuration rather than writing Logstash configuration
+# snippets by hand.
+
+replicaCount: 1
+
+image:
+  repository: docker.elastic.co/logstash/logstash
+  tag: "8.11.0"
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+  automount: true
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+securityContext: {}
+
+service:
+  enabled: true
+  type: ClusterIP
+  port: 9600
+  annotations: {}
+  labels: {}
+
+resources: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+extraEnv: []
+extraEnvFrom: []
+extraVolumeMounts: []
+extraVolumes: []
+extraInitContainers: []
+extraContainers: []
+
+# Raw Logstash configuration files. The defaults expose the HTTP monitoring endpoint and load the
+# generated pipeline. Use tpl syntax in overrides if you need to interpolate Helm values.
+logstashConfig:
+  logstash.yml: |
+    http.host: "0.0.0.0"
+    monitoring.enabled: false
+  pipelines.yml: |
+    - pipeline.id: main
+      path.config: /usr/share/logstash/pipeline/logstash.conf
+
+# Pipeline configuration options.
+pipeline:
+  # Field that will host the aggregated payload once the event is ready for mapping. Bracket
+  # notation is used throughout the chart; the helper templates will automatically add brackets if
+  # they are omitted (e.g. "payload" becomes "[payload]").
+  payloadField: "payload"
+  keepPayloadField: false
+
+  # Optional list of fields to remove after mapping (in addition to the payload field when
+  # keepPayloadField is false). Use Logstash bracket notation for nested fields.
+  removeFields: []
+
+  # When true, events without a payload (after enrichment attempts) are tagged with
+  # `missing_payload`. If `dropOnMissingPayload` is also true those tagged events are dropped.
+  tagMissingPayload: true
+  dropOnMissingPayload: false
+
+  # Optional static fields that should be added to every event prior to the output stage.
+  staticFields: {}
+
+  kafka:
+    bootstrapServers:
+      - kafka:9092
+    topics:
+      - events
+    groupId: logstash-indexer
+    clientId: ""
+    autoOffsetReset: latest
+    securityProtocol: PLAINTEXT
+    decorateEvents: false
+    consumerThreads: 1
+
+    # Additional arbitrary kafka input plugin options expressed as key/value pairs. Values can be
+    # strings, numbers, or booleans.
+    additionalOptions: {}
+
+    codec: json
+
+    sasl:
+      enabled: false
+      mechanism: PLAIN
+      username: ""
+      password:
+        value: ""
+        existingSecret: ""
+        key: ""
+        envVar: KAFKA_SASL_PASSWORD
+
+    ssl:
+      enabled: false
+      truststore: ""
+      truststorePassword:
+        value: ""
+        existingSecret: ""
+        key: ""
+        envVar: KAFKA_TRUSTSTORE_PASSWORD
+      keystore: ""
+      keystorePassword:
+        value: ""
+        existingSecret: ""
+        key: ""
+        envVar: KAFKA_KEYSTORE_PASSWORD
+      verify: true
+
+  # Field used to route events to the correct enrichment source. When empty the chart only relies on
+  # payload detection logic.
+  sourceTypeField: "source.type"
+
+  inline:
+    enabled: true
+    # Values of the sourceTypeField that identify inline payload events.
+    matchSourceTypes:
+      - inline
+    # Field containing the inline payload. If the field already matches pipeline.payloadField the
+    # data is simply parsed/copied in place. When empty the chart will only use fallback logic.
+    payloadField: "payload"
+    # Whether the payload field contains a JSON string instead of an object.
+    payloadIsJsonString: false
+    # Copy selected root fields into the payload hash when the payload field is missing. When left
+    # empty the chart copies the keys defined in `fieldMappings`.
+    fallbackToRootFields: false
+    rootFieldWhitelist: []
+    # Remove the original inline payload field after it has been merged into the canonical payload.
+    removeSourceAfterExtract: false
+
+  dataSources:
+    rest:
+      enabled: false
+      matchSourceTypes:
+        - rest
+      # Field whose value is used when building the request (for example the record identifier).
+      referenceField: "source.id"
+      fetchCondition: missingPayload # allowed values: missingPayload, always
+      request:
+        urlTemplate: https://api.example.tld/resources/%{[source][id]}
+        method: GET
+        headers: {}
+        params: {}
+        body: ""
+        timeoutSeconds: 60
+        proxy: ""
+      response:
+        format: json # json or text
+        jsonPointer: ""
+        targetField: "" # defaults to pipeline.payloadField when empty
+        statusField: "" # optional field to expose the HTTP status code
+      mergeStrategy: replace # replace or merge
+      allowFailure: false
+
+    mongo:
+      enabled: false
+      matchSourceTypes:
+        - mongo
+      referenceField: "source.id"
+      fetchCondition: missingPayload
+      uri: mongodb://user:password@mongo:27017/database
+      database: sample
+      collection: records
+      queryTemplate: '{ "_id": { "$oid": "%{[source][id]}" } }'
+      projection: ""
+      resultSelector: "" # optional JSON pointer into the query result
+      targetField: "" # defaults to pipeline.payloadField when empty
+      mergeStrategy: replace
+      allowFailure: false
+
+    s3:
+      enabled: false
+      matchSourceTypes:
+        - s3
+      fetchCondition: missingPayload
+      bucket: example-bucket
+      keyTemplate: "%{[source][s3_key]}"
+      versionIdField: "" # optional field containing an object version identifier
+      region: us-east-1
+      targetField: "" # defaults to pipeline.payloadField when empty
+      mergeStrategy: replace
+      contentFormat: json # json or text
+      jsonPointer: ""
+      clientOptions: {}
+      assumeRoleArn: ""
+      allowFailure: false
+
+  # Field mappings from the source payload to the final indexed document. Keys are the source field
+  # names and values are the target field names. The chart will automatically pull the source values
+  # out of the payload and place them at the root event level with the target names so that the
+  # Logstash outputs index the correct fields. Advanced options are available by using an object as
+  # the value, for example:
+  #   fieldMappings:
+  #     title:
+  #       target: title_s
+  #       sourcePath: payload.title
+  #       keepSource: false
+  fieldMappings: {}
+
+  # Optional additional mutate remove instructions applied after the field mappings are processed.
+  removeMappedSourceFields: true
+
+  # Optional filters that should run after all built-in enrichment logic but before the output
+  # section. Each entry should be a Logstash filter snippet (without the surrounding `filter { }`).
+  # Use this sparingly – the intent is to cover corner cases not addressed by the built-in switches.
+  additionalFilters: []
+
+output:
+  type: elasticsearch # allowed values: elasticsearch, solr
+
+  elasticsearch:
+    hosts:
+      - http://elasticsearch:9200
+    index: logstash-%{+YYYY.MM.dd}
+    documentIdField: "" # optional source field containing the document id
+    dataStream: {} # optional map of datastream options (e.g. { enabled: true, type: logs, dataset: custom })
+    manageTemplate: true
+    action: index
+    user: ""
+    password:
+      value: ""
+      existingSecret: ""
+      key: ""
+      envVar: ELASTICSEARCH_PASSWORD
+    apiKey:
+      value: ""
+      existingSecret: ""
+      key: ""
+      envVar: ELASTICSEARCH_API_KEY
+    ssl:
+      enabled: false
+      cacertSecret: ""
+      cacertKey: ""
+      certificateAuthority: ""
+      verify: true
+    additionalOptions: {}
+
+  solr:
+    url: http://solr:8983/solr/gettingstarted
+    collection: ""
+    commitWithin: ""
+    softCommit: false
+    skipCommit: false
+    user: ""
+    password:
+      value: ""
+      existingSecret: ""
+      key: ""
+      envVar: SOLR_PASSWORD
+    additionalOptions: {}
+
+  # Additional raw Logstash output snippets (without the surrounding `output { }`).
+  extraOutputs: []


### PR DESCRIPTION
## Summary
- refactor the Logstash pipeline to load ruby filters from dedicated script files bundled via a new ConfigMap
- update the REST enrichment flow to rely on http/json/mutate filters while keeping Mongo and S3 lookups in reusable ruby helpers
- document the helper scripts and REST plugin usage so configuration stays declarative through values.yaml

## Testing
- `helm lint charts/logstash-indexer` *(fails: helm not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cba8bdc4e0832caa7a7643d620d314